### PR TITLE
Feat: US 6 finish the menu upload and review feature in the restaurant mode.

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,6 +24,10 @@ export default function RootLayout() {
       <Stack.Screen name="diner-profile" options={noSwipeOptions} />
       <Stack.Screen name="restaurant-home" options={noSwipeOptions} />
       <Stack.Screen name="restaurant-menu" options={noSwipeOptions} />
+      <Stack.Screen name="restaurant-menu-processing" options={noSwipeOptions} />
+      <Stack.Screen name="restaurant-review-menu" options={noSwipeOptions} />
+      <Stack.Screen name="restaurant-add-dish" options={noSwipeOptions} />
+      <Stack.Screen name="restaurant-edit-dish/[dishId]" options={noSwipeOptions} />
       <Stack.Screen name="restaurant-highlight" options={noSwipeOptions} />
       <Stack.Screen name="restaurant-profile" options={noSwipeOptions} />
     </Stack>

--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -16,7 +16,7 @@ export default function ForgotPasswordScreen() {
       <View style={{ height: insets.top + 36 }} />
       <Text style={styles.heading}>Forgot password?</Text>
       <Text style={styles.subtitle}>
-        Enter your email and we'll send you a link to reset your password.
+        {"Enter your email and we'll send you a link to reset your password."}
       </Text>
       <PrimaryButton text="Back to Login" onPress={() => router.back()} />
     </ScreenContainer>

--- a/app/restaurant-add-dish.tsx
+++ b/app/restaurant-add-dish.tsx
@@ -1,0 +1,661 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Image, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { restaurantRoleTheme } from '@/constants/role-theme';
+import { Colors, Typography } from '@/constants/theme';
+import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+import { generateRestaurantDishImage } from '@/lib/restaurant-dish-image-api';
+import { pickAndUploadRestaurantDishPhoto } from '@/lib/restaurant-dish-photo-upload';
+import { generateRestaurantDishSummary } from '@/lib/restaurant-dish-summary-api';
+import { createRestaurantDishDraft, getRestaurantSectionNextDishSortOrder, saveRestaurantDish } from '@/lib/restaurant-menu-dishes';
+
+const t = restaurantRoleTheme;
+
+type SpiceLevel = 0 | 1 | 2 | 3;
+
+function parsePriceToAmount(input: string): { amount: number | null; currency: string; display: string | null } {
+  const raw = input.trim();
+  if (!raw) return { amount: null, currency: 'USD', display: null };
+
+  let currency = 'USD';
+  const hasDollar = raw.includes('$');
+  const hasEuro = raw.includes('€');
+  const hasPound = raw.includes('£');
+  const hasYen = raw.includes('¥');
+
+  if (hasDollar) currency = 'USD';
+  else if (hasEuro) currency = 'EUR';
+  else if (hasPound) currency = 'GBP';
+  else if (hasYen) currency = 'JPY';
+
+  const numeric = raw.replace(/[^0-9.,-]/g, '').replace(/,/g, '');
+  const n = Number(numeric);
+  return {
+    amount: Number.isFinite(n) ? n : null,
+    currency,
+    display: raw,
+  };
+}
+
+/** Comma-separated: "chicken, potato, onion" → ["chicken", "potato", "onion"]. */
+function parseIngredientsText(input: string): string[] {
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseTagsText(input: string): string[] {
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export default function RestaurantAddDishScreen() {
+  useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ scanId?: string | string[]; sectionId?: string | string[] }>();
+
+  const scanIdRaw = params.scanId;
+  const sectionIdRaw = params.sectionId;
+  const scanId = Array.isArray(scanIdRaw) ? scanIdRaw[0] : scanIdRaw;
+  const sectionId = Array.isArray(sectionIdRaw) ? sectionIdRaw[0] : sectionIdRaw;
+
+  const [dishId, setDishId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dishImageUrl, setDishImageUrl] = useState<string | null>(null);
+
+  const [name, setName] = useState('');
+  const [priceText, setPriceText] = useState('');
+  const [summary, setSummary] = useState('');
+  const [ingredientsText, setIngredientsText] = useState('');
+  const [tagsText, setTagsText] = useState('');
+  const [spiceLevel, setSpiceLevel] = useState<SpiceLevel>(0);
+
+  const [imageLoading, setImageLoading] = useState(false);
+  const [uploadPhotoLoading, setUploadPhotoLoading] = useState(false);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+
+  const ingredients = useMemo(() => parseIngredientsText(ingredientsText), [ingredientsText]);
+  const tags = useMemo(() => parseTagsText(tagsText), [tagsText]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!scanId || !sectionId) {
+        setLoading(false);
+        return;
+      }
+      try {
+        const nextSort = await getRestaurantSectionNextDishSortOrder(sectionId);
+        const draft = await createRestaurantDishDraft({ sectionId, sortOrder: nextSort });
+        if (!cancelled && draft.ok) setDishId(draft.dishId);
+      } catch (e) {
+        if (!cancelled) {
+          Alert.alert('Could not create dish', e instanceof Error ? e.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scanId, sectionId]);
+
+  type CommitResult = { ok: true } | { ok: false; error: string };
+
+  const commitCurrentFields = useCallback(
+    async (opts?: { touchScan?: boolean; description?: string | null }): Promise<CommitResult> => {
+      if (!dishId || !scanId) {
+        return { ok: false, error: 'Missing scan or dish. Go back and open Add dish again.' };
+      }
+      const { amount, currency, display } = parsePriceToAmount(priceText);
+      const currentDescription = (opts?.description ?? summary).trim();
+      const descValue = currentDescription.length ? currentDescription : null;
+
+      const result = await saveRestaurantDish({
+        dishId,
+        scanId,
+        name: name.trim(),
+        description: descValue,
+        priceAmount: amount,
+        priceCurrency: currency,
+        priceDisplay: display,
+        spiceLevel,
+        tags,
+        ingredients,
+        touchScan: opts?.touchScan ?? false,
+      });
+      if (!result.ok) return { ok: false, error: result.error };
+      return { ok: true };
+    },
+    [dishId, scanId, ingredients, name, priceText, spiceLevel, summary, tags],
+  );
+
+  const onUploadPhoto = useCallback(async () => {
+    if (!dishId) return;
+    setImageError(null);
+    setUploadPhotoLoading(true);
+    try {
+      const res = await pickAndUploadRestaurantDishPhoto(dishId);
+      if (res.ok) {
+        setDishImageUrl(res.publicUrl);
+      } else if (!('cancelled' in res && res.cancelled)) {
+        setImageError('error' in res && typeof res.error === 'string' ? res.error : 'Upload failed');
+      }
+    } finally {
+      setUploadPhotoLoading(false);
+    }
+  }, [dishId]);
+
+  const onGenerateImage = useCallback(async () => {
+    if (!dishId) return;
+    setImageError(null);
+    setImageLoading(true);
+    try {
+      const commit = await commitCurrentFields({ touchScan: false });
+      if (!commit.ok) {
+        setImageError(commit.error);
+        Alert.alert('Could not save dish', commit.error);
+        return;
+      }
+      const res = await generateRestaurantDishImage(dishId);
+      if (!res.ok) {
+        setImageError(res.error);
+        Alert.alert('Generate image failed', res.error);
+      } else {
+        setDishImageUrl(res.imageUrl);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      setImageError(msg);
+      Alert.alert('Generate image failed', msg);
+    } finally {
+      setImageLoading(false);
+    }
+  }, [commitCurrentFields, dishId]);
+
+  const onGenerateSummary = useCallback(async () => {
+    if (!dishId) return;
+    setSummaryError(null);
+    setSummaryLoading(true);
+    try {
+      const commit = await commitCurrentFields({ touchScan: false, description: summary });
+      if (!commit.ok) {
+        setSummaryError(commit.error);
+        Alert.alert('Could not save dish', commit.error);
+        return;
+      }
+      const res = await generateRestaurantDishSummary(dishId);
+      if (res.ok) {
+        const next = (res.description ?? '').trim();
+        setSummary(next);
+        if (!next) {
+          Alert.alert(
+            'Summary',
+            'No description was returned. Add ingredients or a clearer dish name, check that EXPO_PUBLIC_MENU_API_URL points to your backend, and try again.',
+          );
+        }
+      } else {
+        setSummaryError(res.error);
+        Alert.alert('Generate summary failed', res.error);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      setSummaryError(msg);
+      Alert.alert('Generate summary failed', msg);
+    } finally {
+      setSummaryLoading(false);
+    }
+  }, [dishId, commitCurrentFields, summary]);
+
+  const onSaveDish = useCallback(async () => {
+    if (!dishId || !scanId) return;
+    if (!name.trim()) {
+      Alert.alert('Dish name', 'Please enter a dish name.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const { amount, currency, display } = parsePriceToAmount(priceText);
+      const result = await saveRestaurantDish({
+        dishId,
+        scanId,
+        name: name.trim(),
+        description: summary.trim().length ? summary.trim() : null,
+        priceAmount: amount,
+        priceCurrency: currency,
+        priceDisplay: display,
+        spiceLevel,
+        tags,
+        ingredients,
+        touchScan: true,
+      });
+      if (!result.ok) {
+        Alert.alert('Save failed', result.error);
+        return;
+      }
+      router.replace({ pathname: '/restaurant-review-menu', params: { scanId } });
+    } catch (e) {
+      Alert.alert('Save failed', e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setSaving(false);
+    }
+  }, [dishId, scanId, ingredients, name, priceText, router, spiceLevel, summary, tags]);
+
+  const spiceOptions: { level: SpiceLevel; label: string }[] = [
+    { level: 0, label: 'None' },
+    { level: 1, label: ' ' },
+    { level: 2, label: ' ' },
+    { level: 3, label: ' ' },
+  ];
+
+  return (
+    <View style={styles.root}>
+      <View style={[styles.headerWrap, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            onPress={() => router.back()}
+            style={({ pressed }) => [styles.backBtn, pressed && { opacity: 0.85 }]}
+          >
+            <Text style={styles.backArrow}>←</Text>
+          </Pressable>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            Add New Dish
+          </Text>
+          <View style={styles.headerRight} />
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={styles.centerBlock}>
+          <ActivityIndicator color={t.primary} />
+          <Text style={{ marginTop: 12, ...Typography.body, color: Colors.textSecondary }}>Preparing dish…</Text>
+        </View>
+      ) : (
+        <>
+          <ScrollView
+            style={styles.scroll}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 120 }]}
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Dish Photo</Text>
+              <View style={styles.photoPlaceholder}>
+                {dishImageUrl ? (
+                  <Image source={{ uri: dishImageUrl }} style={styles.photoImage} />
+                ) : (
+                  <MaterialCommunityIcons name="image-outline" size={48} color="#99A1AF" />
+                )}
+              </View>
+              <View style={styles.photoButtonsRow}>
+                <Pressable
+                  onPress={() => void onUploadPhoto()}
+                  disabled={!dishId || uploadPhotoLoading || imageLoading}
+                  style={({ pressed }) => [
+                    styles.btnUpload,
+                    (!dishId || uploadPhotoLoading || imageLoading) && styles.btnDisabled,
+                    pressed && { opacity: 0.9 },
+                  ]}
+                >
+                  {uploadPhotoLoading ? (
+                    <ActivityIndicator color={Colors.text} />
+                  ) : (
+                    <Text style={styles.btnUploadText}>Upload Photo</Text>
+                  )}
+                </Pressable>
+                <Pressable
+                  onPress={() => void onGenerateImage()}
+                  disabled={!dishId || imageLoading}
+                  style={({ pressed }) => [
+                    styles.btnGenerateAi,
+                    { backgroundColor: t.primary, borderColor: '#D1D5DC' },
+                    !dishId && styles.btnDisabled,
+                    pressed && { opacity: 0.92 },
+                  ]}
+                >
+                  {imageLoading ? (
+                    <ActivityIndicator color={Colors.white} />
+                  ) : (
+                    <Text style={styles.btnGenerateAiText}>Generate by AI</Text>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Dish Name</Text>
+              <TextInput
+                value={name}
+                onChangeText={setName}
+                placeholder="e.g., Spicy Chicken Tacos"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+                autoCapitalize="words"
+              />
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Price</Text>
+              <TextInput
+                value={priceText}
+                onChangeText={setPriceText}
+                placeholder="e.g., $12"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+                keyboardType="decimal-pad"
+              />
+            </View>
+
+            <View style={styles.section}>
+              <View style={styles.summaryHeaderRow}>
+                <Text style={styles.fieldLabel}>Summary</Text>
+                <Pressable
+                  onPress={() => void onGenerateSummary()}
+                  disabled={!dishId || !scanId || summaryLoading}
+                  style={({ pressed }) => [
+                    styles.summaryAiPill,
+                    { backgroundColor: t.primary },
+                    (!dishId || !scanId || summaryLoading) && { opacity: 0.5 },
+                    pressed && { opacity: 0.9 },
+                  ]}
+                >
+                  <Text style={styles.summaryAiPillText}>{summaryLoading ? '…' : 'Generate by AI'}</Text>
+                </Pressable>
+              </View>
+              <TextInput
+                value={summary}
+                onChangeText={setSummary}
+                placeholder="Brief description of the dish..."
+                placeholderTextColor="#6A7282"
+                style={[styles.input, styles.summaryInput]}
+                multiline
+                textAlignVertical="top"
+              />
+              {summaryError ? <Text style={styles.errorText}>{summaryError}</Text> : null}
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Spice Level</Text>
+              <View style={styles.spiceRow}>
+                {spiceOptions.map((opt) => {
+                  const active = spiceLevel === opt.level;
+                  const iconCount = opt.level === 0 ? 0 : opt.level;
+                  return (
+                    <Pressable
+                      key={opt.level}
+                      accessibilityRole="button"
+                      onPress={() => setSpiceLevel(opt.level)}
+                      style={({ pressed }) => [
+                        styles.spiceCell,
+                        active
+                          ? { backgroundColor: t.primaryDark, borderColor: t.primaryDark }
+                          : { backgroundColor: '#FFFFFF', borderColor: '#99A1AF' },
+                        pressed && { opacity: 0.88 },
+                      ]}
+                    >
+                      {opt.level === 0 ? (
+                        <Text style={[styles.spiceNoneText, active && { color: Colors.white }]}>None</Text>
+                      ) : (
+                        <Text style={[styles.spiceFireText, active && { opacity: 1 }]}>{'🔥'.repeat(iconCount)}</Text>
+                      )}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Ingredients</Text>
+              <TextInput
+                value={ingredientsText}
+                onChangeText={setIngredientsText}
+                placeholder="Comma-separated ingredients..."
+                placeholderTextColor="#6A7282"
+                style={[styles.input, styles.ingredientsInput]}
+                multiline
+                textAlignVertical="top"
+              />
+              <Text style={styles.ingredientsHint}>Separate ingredients with commas</Text>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>AI Generated Tags (optional)</Text>
+              <TextInput
+                value={tagsText}
+                onChangeText={setTagsText}
+                placeholder="Comma-separated tags"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+              />
+            </View>
+
+            {imageError ? <Text style={styles.errorText}>{imageError}</Text> : null}
+          </ScrollView>
+
+          <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]}>
+            <PrimaryButton
+              text="Save Dish"
+              onPress={() => void onSaveDish()}
+              loading={saving}
+              disabled={saving}
+              accentColor={t.primary}
+              accentShadowRgb={t.shadowRgb}
+              style={styles.saveBtn}
+            />
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: Colors.white },
+  headerWrap: {
+    backgroundColor: Colors.white,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  header: {
+    height: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+  },
+  backBtn: {
+    minWidth: 32,
+    height: 32,
+    paddingHorizontal: 6,
+    borderRadius: 9999,
+    backgroundColor: '#F3F4F6',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backArrow: {
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 27,
+    letterSpacing: -0.44,
+    color: Colors.text,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 24,
+    letterSpacing: -0.31,
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  headerRight: { width: 32 },
+  centerBlock: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  scroll: { flex: 1 },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    gap: 20,
+  },
+  section: {
+    gap: 8,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  photoPlaceholder: {
+    height: 160,
+    borderRadius: 14,
+    backgroundColor: '#F3F4F6',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  photoImage: { width: '100%', height: '100%' },
+  photoButtonsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  btnUpload: {
+    flex: 133,
+    height: 40,
+    borderRadius: 14,
+    backgroundColor: Colors.white,
+    borderWidth: 1,
+    borderColor: '#D1D5DC',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnUploadText: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  btnGenerateAi: {
+    flex: 178,
+    height: 40,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnGenerateAiText: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.white,
+  },
+  btnDisabled: { opacity: 0.45 },
+  input: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: '#D1D5DC',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: -0.15,
+    color: Colors.text,
+    backgroundColor: Colors.white,
+  },
+  summaryHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 24.5,
+  },
+  summaryAiPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 10,
+    minWidth: 105,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  summaryAiPillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    color: Colors.white,
+  },
+  summaryInput: {
+    height: 89,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  spiceRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  spiceCell: {
+    flex: 1,
+    height: 41,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+  },
+  spiceNoneText: {
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  spiceFireText: {
+    fontSize: 14,
+    lineHeight: 21,
+    opacity: 0.85,
+  },
+  ingredientsInput: {
+    height: 110,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  ingredientsHint: {
+    fontSize: 12,
+    lineHeight: 18,
+    color: '#6A7282',
+    marginTop: 4,
+  },
+  errorText: { ...Typography.captionMedium, color: Colors.error, marginTop: 4 },
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 24,
+    paddingTop: 21,
+    backgroundColor: Colors.white,
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+  },
+  saveBtn: {
+    height: 56,
+    borderRadius: 14,
+    width: '100%',
+  },
+});

--- a/app/restaurant-edit-dish/[dishId].tsx
+++ b/app/restaurant-edit-dish/[dishId].tsx
@@ -1,0 +1,675 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Image, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { restaurantRoleTheme } from '@/constants/role-theme';
+import { Colors, Typography } from '@/constants/theme';
+import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+import { supabase } from '@/lib/supabase';
+import { generateRestaurantDishImage } from '@/lib/restaurant-dish-image-api';
+import { pickAndUploadRestaurantDishPhoto } from '@/lib/restaurant-dish-photo-upload';
+import { generateRestaurantDishSummary } from '@/lib/restaurant-dish-summary-api';
+import { saveRestaurantDish } from '@/lib/restaurant-menu-dishes';
+
+type SpiceLevel = 0 | 1 | 2 | 3;
+
+const t = restaurantRoleTheme;
+
+function parsePriceToAmount(input: string): { amount: number | null; currency: string; display: string | null } {
+  const raw = input.trim();
+  if (!raw) return { amount: null, currency: 'USD', display: null };
+
+  let currency = 'USD';
+  if (raw.includes('$')) currency = 'USD';
+  else if (raw.includes('€')) currency = 'EUR';
+  else if (raw.includes('£')) currency = 'GBP';
+  else if (raw.includes('¥')) currency = 'JPY';
+
+  const numeric = raw.replace(/[^0-9.,-]/g, '').replace(/,/g, '');
+  const n = Number(numeric);
+  return { amount: Number.isFinite(n) ? n : null, currency, display: raw };
+}
+
+function parseIngredientsText(input: string): string[] {
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseTagsText(input: string): string[] {
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export default function RestaurantEditDishScreen() {
+  useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ dishId?: string; scanId?: string | string[] }>();
+
+  const dishId = params.dishId ? String(params.dishId) : null;
+  const scanIdRaw = params.scanId;
+  const scanId = Array.isArray(scanIdRaw) ? scanIdRaw[0] : scanIdRaw ? String(scanIdRaw) : null;
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dishImageUrl, setDishImageUrl] = useState<string | null>(null);
+
+  const [name, setName] = useState('');
+  const [priceText, setPriceText] = useState('');
+  const [summary, setSummary] = useState('');
+  const [ingredientsText, setIngredientsText] = useState('');
+  const [tagsText, setTagsText] = useState('');
+  const [spiceLevel, setSpiceLevel] = useState<SpiceLevel>(0);
+
+  const [imageLoading, setImageLoading] = useState(false);
+  const [uploadPhotoLoading, setUploadPhotoLoading] = useState(false);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!dishId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        setLoading(true);
+        const { data, error } = await supabase
+          .from('restaurant_menu_dishes')
+          .select('id, name, description, price_amount, price_currency, price_display, spice_level, tags, ingredients, image_url')
+          .eq('id', dishId)
+          .maybeSingle();
+        if (error) throw error;
+        if (!data) {
+          if (!cancelled) Alert.alert('Dish not found');
+          return;
+        }
+        if (cancelled) return;
+
+        setDishImageUrl(data.image_url ?? null);
+        setName(data.name ?? '');
+        setSummary(data.description ?? '');
+        setSpiceLevel((data.spice_level ?? 0) as SpiceLevel);
+
+        const priceDisplay = data.price_display ?? (data.price_amount != null ? `$${data.price_amount}` : '');
+        setPriceText(priceDisplay ?? '');
+
+        const ingredients = Array.isArray(data.ingredients) ? data.ingredients : [];
+        setIngredientsText(ingredients.join(', '));
+
+        const tags = Array.isArray(data.tags) ? data.tags : [];
+        setTagsText(tags.join(', '));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dishId]);
+
+  const ingredients = useMemo(() => parseIngredientsText(ingredientsText), [ingredientsText]);
+  const tags = useMemo(() => parseTagsText(tagsText), [tagsText]);
+
+  const onUploadPhoto = useCallback(async () => {
+    if (!dishId) return;
+    setImageError(null);
+    setUploadPhotoLoading(true);
+    try {
+      const res = await pickAndUploadRestaurantDishPhoto(dishId);
+      if (res.ok) {
+        setDishImageUrl(res.publicUrl);
+      } else if (!('cancelled' in res && res.cancelled)) {
+        setImageError('error' in res && typeof res.error === 'string' ? res.error : 'Upload failed');
+      }
+    } finally {
+      setUploadPhotoLoading(false);
+    }
+  }, [dishId]);
+
+  const onGenerateImage = useCallback(async () => {
+    if (!dishId) return;
+    if (!scanId) {
+      Alert.alert('Missing context', 'scanId is required for generating dish AI outputs.');
+      return;
+    }
+    setImageError(null);
+    setImageLoading(true);
+    try {
+      const { amount, currency, display } = parsePriceToAmount(priceText);
+      const saved = await saveRestaurantDish({
+        dishId,
+        scanId,
+        name: name.trim(),
+        description: summary.trim().length ? summary.trim() : null,
+        priceAmount: amount,
+        priceCurrency: currency,
+        priceDisplay: display,
+        spiceLevel,
+        tags,
+        ingredients,
+        touchScan: false,
+      });
+      if (!saved.ok) {
+        setImageError(saved.error);
+        Alert.alert('Could not save dish', saved.error);
+        return;
+      }
+
+      const res = await generateRestaurantDishImage(dishId);
+      if (res.ok) setDishImageUrl(res.imageUrl);
+      else {
+        setImageError(res.error);
+        Alert.alert('Generate image failed', res.error);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      setImageError(msg);
+      Alert.alert('Generate image failed', msg);
+    } finally {
+      setImageLoading(false);
+    }
+  }, [dishId, scanId, ingredients, name, priceText, spiceLevel, summary, tags]);
+
+  const onGenerateSummary = useCallback(async () => {
+    if (!dishId) return;
+    setSummaryError(null);
+    setSummaryLoading(true);
+    try {
+      if (!scanId) {
+        Alert.alert('Missing context', 'scanId is required for generating dish AI outputs.');
+        return;
+      }
+
+      const { amount, currency, display } = parsePriceToAmount(priceText);
+      const saved = await saveRestaurantDish({
+        dishId,
+        scanId,
+        name: name.trim(),
+        description: summary.trim().length ? summary.trim() : null,
+        priceAmount: amount,
+        priceCurrency: currency,
+        priceDisplay: display,
+        spiceLevel,
+        tags,
+        ingredients,
+        touchScan: false,
+      });
+      if (!saved.ok) {
+        setSummaryError(saved.error);
+        Alert.alert('Could not save dish', saved.error);
+        return;
+      }
+
+      const res = await generateRestaurantDishSummary(dishId);
+      if (res.ok) {
+        const next = (res.description ?? '').trim();
+        setSummary(next);
+        if (!next) {
+          Alert.alert(
+            'Summary',
+            'No description was returned. Add ingredients or a clearer dish name, check EXPO_PUBLIC_MENU_API_URL, and try again.',
+          );
+        }
+      } else {
+        setSummaryError(res.error);
+        Alert.alert('Generate summary failed', res.error);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      setSummaryError(msg);
+      Alert.alert('Generate summary failed', msg);
+    } finally {
+      setSummaryLoading(false);
+    }
+  }, [dishId, scanId, ingredients, name, priceText, spiceLevel, summary, tags]);
+
+  const onSaveDish = useCallback(async () => {
+    if (!dishId || !scanId) {
+      Alert.alert('Missing context', 'Dish scanId is required to save.');
+      return;
+    }
+    if (!name.trim()) {
+      Alert.alert('Dish name', 'Please enter a dish name.');
+      return;
+    }
+    const { amount, currency, display } = parsePriceToAmount(priceText);
+
+    setSaving(true);
+    try {
+      const result = await saveRestaurantDish({
+        dishId,
+        scanId,
+        name: name.trim(),
+        description: summary.trim().length ? summary.trim() : null,
+        priceAmount: amount,
+        priceCurrency: currency,
+        priceDisplay: display,
+        spiceLevel,
+        tags,
+        ingredients,
+        touchScan: true,
+      });
+      if (!result.ok) {
+        Alert.alert('Save failed', result.error);
+        return;
+      }
+      router.replace({ pathname: '/restaurant-review-menu', params: { scanId } });
+    } catch (e) {
+      Alert.alert('Save failed', e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setSaving(false);
+    }
+  }, [dishId, scanId, ingredients, name, priceText, router, spiceLevel, summary, tags]);
+
+  const spiceOptions: { level: SpiceLevel; label: string }[] = [
+    { level: 0, label: 'None' },
+    { level: 1, label: ' ' },
+    { level: 2, label: ' ' },
+    { level: 3, label: ' ' },
+  ];
+
+  return (
+    <View style={styles.root}>
+      <View style={[styles.headerWrap, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            onPress={() => router.back()}
+            style={({ pressed }) => [styles.backBtn, pressed && { opacity: 0.85 }]}
+          >
+            <Text style={styles.backArrow}>←</Text>
+          </Pressable>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            Edit Dish
+          </Text>
+          <View style={styles.headerRight} />
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={styles.centerBlock}>
+          <ActivityIndicator color={t.primary} />
+          <Text style={{ marginTop: 12, ...Typography.body, color: Colors.textSecondary }}>Loading dish…</Text>
+        </View>
+      ) : (
+        <>
+          <ScrollView
+            style={styles.scroll}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 120 }]}
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Dish Photo</Text>
+              <View style={styles.photoPlaceholder}>
+                {dishImageUrl ? (
+                  <Image source={{ uri: dishImageUrl }} style={styles.photoImage} />
+                ) : (
+                  <MaterialCommunityIcons name="image-outline" size={48} color="#99A1AF" />
+                )}
+              </View>
+              <View style={styles.photoButtonsRow}>
+                <Pressable
+                  onPress={() => void onUploadPhoto()}
+                  disabled={!dishId || uploadPhotoLoading || imageLoading}
+                  style={({ pressed }) => [
+                    styles.btnUpload,
+                    (!dishId || uploadPhotoLoading || imageLoading) && styles.btnDisabled,
+                    pressed && { opacity: 0.9 },
+                  ]}
+                >
+                  {uploadPhotoLoading ? (
+                    <ActivityIndicator color={Colors.text} />
+                  ) : (
+                    <Text style={styles.btnUploadText}>Upload Photo</Text>
+                  )}
+                </Pressable>
+                <Pressable
+                  onPress={() => void onGenerateImage()}
+                  disabled={!dishId || imageLoading}
+                  style={({ pressed }) => [
+                    styles.btnGenerateAi,
+                    { backgroundColor: t.primary, borderColor: '#D1D5DC' },
+                    !dishId && styles.btnDisabled,
+                    pressed && { opacity: 0.92 },
+                  ]}
+                >
+                  {imageLoading ? (
+                    <ActivityIndicator color={Colors.white} />
+                  ) : (
+                    <Text style={styles.btnGenerateAiText}>Generate by AI</Text>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Dish Name</Text>
+              <TextInput
+                value={name}
+                onChangeText={setName}
+                placeholder="e.g., Spicy Chicken Tacos"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+                autoCapitalize="words"
+              />
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Price</Text>
+              <TextInput
+                value={priceText}
+                onChangeText={setPriceText}
+                placeholder="e.g., $12"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+                keyboardType="decimal-pad"
+              />
+            </View>
+
+            <View style={styles.section}>
+              <View style={styles.summaryHeaderRow}>
+                <Text style={styles.fieldLabel}>Summary</Text>
+                <Pressable
+                  onPress={() => void onGenerateSummary()}
+                  disabled={!dishId || summaryLoading}
+                  style={({ pressed }) => [
+                    styles.summaryAiPill,
+                    { backgroundColor: t.primary },
+                    (!dishId || summaryLoading) && { opacity: 0.5 },
+                    pressed && { opacity: 0.9 },
+                  ]}
+                >
+                  <Text style={styles.summaryAiPillText}>{summaryLoading ? '…' : 'Generate by AI'}</Text>
+                </Pressable>
+              </View>
+              <TextInput
+                value={summary}
+                onChangeText={setSummary}
+                placeholder="Brief description of the dish..."
+                placeholderTextColor="#6A7282"
+                style={[styles.input, styles.summaryInput]}
+                multiline
+                textAlignVertical="top"
+              />
+              {summaryError ? <Text style={styles.errorText}>{summaryError}</Text> : null}
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Spice Level</Text>
+              <View style={styles.spiceRow}>
+                {spiceOptions.map((opt) => {
+                  const active = spiceLevel === opt.level;
+                  const iconCount = opt.level === 0 ? 0 : opt.level;
+                  return (
+                    <Pressable
+                      key={opt.level}
+                      accessibilityRole="button"
+                      onPress={() => setSpiceLevel(opt.level)}
+                      style={({ pressed }) => [
+                        styles.spiceCell,
+                        active
+                          ? { backgroundColor: t.primaryDark, borderColor: t.primaryDark }
+                          : { backgroundColor: '#FFFFFF', borderColor: '#99A1AF' },
+                        pressed && { opacity: 0.88 },
+                      ]}
+                    >
+                      {opt.level === 0 ? (
+                        <Text style={[styles.spiceNoneText, active && { color: Colors.white }]}>None</Text>
+                      ) : (
+                        <Text style={[styles.spiceFireText, active && { opacity: 1 }]}>{'🔥'.repeat(iconCount)}</Text>
+                      )}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>Ingredients</Text>
+              <TextInput
+                value={ingredientsText}
+                onChangeText={setIngredientsText}
+                placeholder="Comma-separated ingredients..."
+                placeholderTextColor="#6A7282"
+                style={[styles.input, styles.ingredientsInput]}
+                multiline
+                textAlignVertical="top"
+              />
+              <Text style={styles.ingredientsHint}>Separate ingredients with commas</Text>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.fieldLabel}>AI Generated Tags (optional)</Text>
+              <TextInput
+                value={tagsText}
+                onChangeText={setTagsText}
+                placeholder="Comma-separated tags"
+                placeholderTextColor="#6A7282"
+                style={styles.input}
+              />
+            </View>
+
+            {imageError ? <Text style={styles.errorText}>{imageError}</Text> : null}
+          </ScrollView>
+
+          <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]}>
+            <PrimaryButton
+              text="Save Dish"
+              onPress={() => void onSaveDish()}
+              loading={saving}
+              disabled={saving}
+              accentColor={t.primary}
+              accentShadowRgb={t.shadowRgb}
+              style={styles.saveBtn}
+            />
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: Colors.white },
+  headerWrap: {
+    backgroundColor: Colors.white,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  header: {
+    height: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+  },
+  backBtn: {
+    minWidth: 32,
+    height: 32,
+    paddingHorizontal: 6,
+    borderRadius: 9999,
+    backgroundColor: '#F3F4F6',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backArrow: {
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 27,
+    letterSpacing: -0.44,
+    color: Colors.text,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 24,
+    letterSpacing: -0.31,
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  headerRight: { width: 32 },
+  centerBlock: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  scroll: { flex: 1 },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    gap: 20,
+  },
+  section: {
+    gap: 8,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  photoPlaceholder: {
+    height: 160,
+    borderRadius: 14,
+    backgroundColor: '#F3F4F6',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  photoImage: { width: '100%', height: '100%' },
+  photoButtonsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  btnUpload: {
+    flex: 133,
+    height: 40,
+    borderRadius: 14,
+    backgroundColor: Colors.white,
+    borderWidth: 1,
+    borderColor: '#D1D5DC',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnUploadText: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  btnGenerateAi: {
+    flex: 178,
+    height: 40,
+    borderRadius: 14,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnGenerateAiText: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.white,
+  },
+  btnDisabled: { opacity: 0.45 },
+  input: {
+    height: 48,
+    borderWidth: 1,
+    borderColor: '#D1D5DC',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: -0.15,
+    color: Colors.text,
+    backgroundColor: Colors.white,
+  },
+  summaryHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 24.5,
+  },
+  summaryAiPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 10,
+    minWidth: 105,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  summaryAiPillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    color: Colors.white,
+  },
+  summaryInput: {
+    height: 89,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  spiceRow: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  spiceCell: {
+    flex: 1,
+    height: 41,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+  },
+  spiceNoneText: {
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 21,
+    letterSpacing: -0.15,
+    color: Colors.text,
+  },
+  spiceFireText: {
+    fontSize: 14,
+    lineHeight: 21,
+    opacity: 0.85,
+  },
+  ingredientsInput: {
+    height: 110,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  ingredientsHint: {
+    fontSize: 12,
+    lineHeight: 18,
+    color: '#6A7282',
+    marginTop: 4,
+  },
+  errorText: { ...Typography.captionMedium, color: Colors.error, marginTop: 4 },
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 24,
+    paddingTop: 21,
+    backgroundColor: Colors.white,
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+  },
+  saveBtn: {
+    height: 56,
+    borderRadius: 14,
+    width: '100%',
+  },
+});

--- a/app/restaurant-home.tsx
+++ b/app/restaurant-home.tsx
@@ -1,70 +1,239 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import * as FileSystem from 'expo-file-system';
+import * as ImagePicker from 'expo-image-picker';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
+import { useCallback, useState } from 'react';
+import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { RestaurantTabScreenLayout } from '@/components/RestaurantTabScreenLayout';
-import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
 import { restaurantRoleTheme } from '@/constants/role-theme';
+import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
-
-const RECENT_UPLOADS = [
-  { id: '1', title: 'Dinner Menu 2024', subtitle: '3 days ago' },
-  { id: '2', title: 'Lunch Specials', subtitle: '1 week ago' },
-];
+import { fetchRestaurantRecentUploads, type RestaurantMenuScanListRow } from '@/lib/restaurant-menu-scans';
+import { formatScannedAtPast } from '@/lib/format-scan-time';
+import { writePendingRestaurantMenuScan } from '@/lib/pending-restaurant-menu-scan';
+import { supabase } from '@/lib/supabase';
+import { MenuUploadError, uploadMenuImageFromUri } from '@/lib/upload-menu-image';
 
 const t = restaurantRoleTheme;
+const MAX_BYTES = 20 * 1024 * 1024;
 
+/** Restaurant Upload Menu (images-only). */
 export default function RestaurantHomeScreen() {
   useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [scansLoading, setScansLoading] = useState(true);
+  const [recentScans, setRecentScans] = useState<RestaurantMenuScanListRow[]>([]);
+
+  const loadRecent = useCallback(async () => {
+    setScansLoading(true);
+    try {
+      const rows = await fetchRestaurantRecentUploads(10);
+      setRecentScans(rows);
+    } catch {
+      setRecentScans([]);
+    } finally {
+      setScansLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadRecent();
+    }, [loadRecent]),
+  );
+
+  const resolveFileSize = useCallback(async (uri: string, fallback?: number | null) => {
+    if (typeof fallback === 'number' && fallback > 0) return fallback;
+    try {
+      const info = await FileSystem.getInfoAsync(uri);
+      if (info.exists && 'size' in info && typeof info.size === 'number') {
+        return info.size;
+      }
+    } catch {
+      // ph:// or unsupported — rely on picker/file metadata
+    }
+    return 0;
+  }, []);
+
+  const startScan = useCallback(
+    async (source: 'camera' | 'library') => {
+      if (busy) return;
+      setBusy(true);
+      try {
+        if (source === 'camera') {
+          const { status } = await ImagePicker.requestCameraPermissionsAsync();
+          if (status !== 'granted') {
+            Alert.alert('Camera', 'Camera access is needed to scan a menu.');
+            return;
+          }
+        } else {
+          const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (status !== 'granted') {
+            Alert.alert('Photos', 'Photo library access is needed to upload a menu image.');
+            return;
+          }
+        }
+
+        const picker =
+          source === 'camera'
+            ? await ImagePicker.launchCameraAsync({
+                mediaTypes: ['images'],
+                quality: 0.85,
+              })
+            : await ImagePicker.launchImageLibraryAsync({
+                mediaTypes: ['images'],
+                quality: 0.85,
+              });
+
+        if (picker.canceled || !picker.assets?.[0]?.uri) return;
+
+        const asset = picker.assets[0];
+        const sizeBytes = await resolveFileSize(asset.uri, asset.fileSize ?? null);
+        if (sizeBytes > MAX_BYTES) {
+          Alert.alert('File too large', 'Please choose an image under 20 MB.');
+          return;
+        }
+
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+          Alert.alert('Sign in required', 'Please sign in to upload a menu.');
+          return;
+        }
+
+        const { bucket, path } = await uploadMenuImageFromUri({
+          localUri: asset.uri,
+          fileSizeBytes: sizeBytes || asset.fileSize || 0,
+          userId: user.id,
+        });
+
+        await writePendingRestaurantMenuScan(bucket, path);
+
+        router.push({
+          pathname: '/restaurant-menu-processing',
+          params: {
+            bucket,
+            storagePath: encodeURIComponent(path),
+          },
+        });
+      } catch (e) {
+        const msg =
+          e instanceof MenuUploadError ? e.message : e instanceof Error ? e.message : 'Something went wrong.';
+        Alert.alert('Upload failed', msg);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, resolveFileSize, router],
+  );
+
+  const cardShadow = Platform.select({
+    ios: {
+      shadowColor: '#E5E7EB',
+      shadowOffset: { width: 0, height: 4 },
+      shadowOpacity: 0.5,
+      shadowRadius: 6,
+    },
+    android: { elevation: 3 },
+    default: {},
+  });
 
   return (
     <RestaurantTabScreenLayout activeTab="home">
       <Text style={styles.title}>Upload your menu</Text>
-      <Text style={styles.subtitle}>
-        {"We'll turn it into a digital menu automatically"}
-      </Text>
+      <Text style={styles.subtitle}>{"We'll turn it into a digital menu automatically"}</Text>
 
-      <View style={[styles.card, { borderColor: t.cardAccentBorder }]}>
-        <Pressable style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}>
-          <View style={[styles.iconBox, { backgroundColor: t.primary }]}>
-            <MaterialCommunityIcons name="camera-outline" size={22} color={Colors.white} />
-          </View>
+      <View style={[styles.card, { borderColor: t.cardAccentBorder }, cardShadow]}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={busy}
+          onPress={() => void startScan('camera')}
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+        >
+          <LinearGradient
+            colors={[t.primaryDark, t.primary, t.primaryLight]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.iconGradient}
+          >
+            <MaterialCommunityIcons name="camera-outline" size={24} color={Colors.white} />
+          </LinearGradient>
           <View style={styles.rowText}>
             <Text style={styles.rowTitle}>Take photo</Text>
             <Text style={styles.rowSubtitle}>Scan your menu</Text>
           </View>
-          <MaterialCommunityIcons name="chevron-right" size={24} color={Colors.textSecondary} />
+          {busy ? (
+            <ActivityIndicator color={t.primaryDark} />
+          ) : (
+            <MaterialCommunityIcons name="chevron-right" size={20} color={Colors.textSecondary} />
+          )}
         </Pressable>
 
         <View style={styles.divider} />
 
-        <Pressable style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}>
-          <View style={[styles.iconBox, { backgroundColor: t.primary }]}>
-            <MaterialCommunityIcons name="image-outline" size={22} color={Colors.white} />
-          </View>
+        <Pressable
+          accessibilityRole="button"
+          disabled={busy}
+          onPress={() => void startScan('library')}
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+        >
+          <LinearGradient
+            colors={[t.primaryDark, t.primary, t.primaryLight]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.iconGradient}
+          >
+            <MaterialCommunityIcons name="image-outline" size={24} color={Colors.white} />
+          </LinearGradient>
           <View style={styles.rowText}>
             <Text style={styles.rowTitle}>Upload menu</Text>
-            <Text style={styles.rowSubtitle}>Choose image or PDF</Text>
+            <Text style={styles.rowSubtitle}>Choose an image</Text>
           </View>
-          <MaterialCommunityIcons name="chevron-right" size={24} color={Colors.textSecondary} />
+          {busy ? (
+            <ActivityIndicator color={t.primaryDark} />
+          ) : (
+            <MaterialCommunityIcons name="chevron-right" size={20} color={Colors.textSecondary} />
+          )}
         </Pressable>
       </View>
 
       <Text style={styles.sectionTitle}>Recent uploads</Text>
-      {RECENT_UPLOADS.map((item) => (
-        <Pressable
-          key={item.id}
-          style={({ pressed }) => [styles.recentCard, { borderColor: t.cardAccentBorder }, pressed && styles.rowPressed]}
-        >
-          <View style={[styles.recentIcon, { backgroundColor: t.primaryLight }]}>
-            <MaterialCommunityIcons name="silverware-fork-knife" size={22} color={t.primary} />
-          </View>
-          <View style={styles.rowText}>
-            <Text style={styles.recentTitle}>{item.title}</Text>
-            <Text style={styles.recentSubtitle}>{item.subtitle}</Text>
-          </View>
-          <MaterialCommunityIcons name="chevron-right" size={24} color={Colors.textSecondary} />
-        </Pressable>
-      ))}
+      {scansLoading ? (
+        <View style={styles.scansLoading}>
+          <ActivityIndicator color={t.primary} />
+        </View>
+      ) : recentScans.length === 0 ? (
+        <Text style={styles.emptyText}>No uploads yet — upload a menu to see it here.</Text>
+      ) : (
+        recentScans.map((item) => (
+          <Pressable
+            key={item.id}
+            accessibilityRole="button"
+            onPress={() => router.push({ pathname: '/restaurant-review-menu', params: { scanId: item.id } })}
+            style={({ pressed }) => [
+              styles.recentCard,
+              { borderColor: t.cardAccentBorder },
+              pressed && styles.rowPressed,
+            ]}
+          >
+            <View style={[styles.recentIcon, { backgroundColor: t.primaryLight }]}>
+              <MaterialCommunityIcons name="silverware-fork-knife" size={22} color={t.primaryDark} />
+            </View>
+            <View style={styles.rowText}>
+              <Text style={styles.recentTitle} numberOfLines={1}>
+                {item.restaurant_name?.trim() || 'Menu'}
+              </Text>
+              <Text style={styles.recentSubtitle}>{formatScannedAtPast(item.last_activity_at)}</Text>
+            </View>
+            <MaterialCommunityIcons name="chevron-right" size={24} color={Colors.textSecondary} />
+          </Pressable>
+        ))
+      )}
     </RestaurantTabScreenLayout>
   );
 }
@@ -100,7 +269,7 @@ const styles = StyleSheet.create({
   rowPressed: {
     opacity: 0.85,
   },
-  iconBox: {
+  iconGradient: {
     width: 48,
     height: 48,
     borderRadius: BorderRadius.base,
@@ -129,6 +298,8 @@ const styles = StyleSheet.create({
     color: Colors.text,
     marginBottom: Spacing.base,
   },
+  scansLoading: { paddingVertical: Spacing.xl, alignItems: 'center' },
+  emptyText: { ...Typography.body, color: Colors.textSecondary, marginBottom: Spacing.base },
   recentCard: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -150,6 +321,7 @@ const styles = StyleSheet.create({
   recentTitle: {
     ...Typography.bodyMedium,
     color: Colors.text,
+    flex: 1,
   },
   recentSubtitle: {
     ...Typography.caption,

--- a/app/restaurant-menu-processing.tsx
+++ b/app/restaurant-menu-processing.tsx
@@ -1,0 +1,293 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, Animated, Easing, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { RestaurantMenuProcessingIllustration } from '@/components/RestaurantMenuProcessingIllustration';
+import { Colors, Spacing } from '@/constants/theme';
+import { restaurantRoleTheme } from '@/constants/role-theme';
+import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+
+import { fetchRestaurantIdForOwner } from '@/lib/restaurant-setup';
+import { buildRestaurantMenuParseUserPreferences } from '@/lib/restaurant-menu-parse-preferences';
+import { parsedMenuHasItems, validateParsedMenu } from '@/lib/menu-scan-schema';
+import { persistRestaurantMenuDraft } from '@/lib/restaurant-persist-menu';
+import { requestMenuParse } from '@/lib/menu-parse-api';
+import { readPendingRestaurantMenuScan, clearPendingRestaurantMenuScan } from '@/lib/pending-restaurant-menu-scan';
+import { MENU_UPLOAD_BUCKET } from '@/lib/upload-menu-image';
+
+const STATUS_MESSAGES = ['Reading menu…', 'Extracting items…', 'Reading prices…', 'Almost done…'];
+
+export default function RestaurantMenuProcessingScreen() {
+  useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ bucket?: string; storagePath?: string | string[] }>();
+
+  const bucketFromParams = typeof params.bucket === 'string' ? params.bucket : MENU_UPLOAD_BUCKET;
+  const pathParam = params.storagePath;
+
+  const [resolvedBucket, setResolvedBucket] = useState(bucketFromParams);
+  const [resolvedPath, setResolvedPath] = useState('');
+
+  const storagePathFromParams = useMemo(() => {
+    const raw = Array.isArray(pathParam) ? pathParam[0] : pathParam;
+    if (!raw || typeof raw !== 'string') return '';
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  }, [pathParam]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (__DEV__) {
+        console.log('[restaurant-menu-scan] processing mount', {
+          rawParams: params,
+          pathParam,
+          storagePathFromParams,
+          bucketFromParams,
+        });
+      }
+
+      if (storagePathFromParams.trim()) {
+        if (!cancelled) {
+          setResolvedPath(storagePathFromParams);
+          setResolvedBucket(bucketFromParams);
+        }
+        return;
+      }
+
+      const pending = await readPendingRestaurantMenuScan();
+      if (!cancelled && pending?.path?.trim()) {
+        setResolvedPath(pending.path);
+        setResolvedBucket(pending.bucket || MENU_UPLOAD_BUCKET);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bucketFromParams, pathParam, storagePathFromParams, params]);
+
+  const bucket = resolvedBucket;
+  const storagePath = resolvedPath;
+
+  const t = restaurantRoleTheme;
+  const [statusIndex, setStatusIndex] = useState(0);
+  const progressAnim = useRef(new Animated.Value(0.08)).current;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setStatusIndex((i) => (i + 1) % STATUS_MESSAGES.length);
+    }, 2200);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(progressAnim, {
+          toValue: 0.92,
+          duration: 1400,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: false,
+        }),
+        Animated.timing(progressAnim, {
+          toValue: 0.12,
+          duration: 1400,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: false,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => {
+      loop.stop();
+    };
+  }, [progressAnim]);
+
+  const failAndHome = useCallback(
+    (title: string, message: string) => {
+      Alert.alert(title, message, [
+        {
+          text: 'OK',
+          onPress: () => router.replace('/restaurant-home'),
+        },
+      ]);
+    },
+    [router],
+  );
+
+  const runPipeline = useCallback(async () => {
+    if (!storagePath.trim()) {
+      failAndHome('Missing file', 'No upload path. Return home and try again.');
+      return;
+    }
+
+    const { restaurantId, error: rErr } = await fetchRestaurantIdForOwner();
+    if (!restaurantId || rErr) {
+      failAndHome('Restaurant required', 'Please complete restaurant setup before uploading a menu.');
+      return;
+    }
+
+    const userPreferences = buildRestaurantMenuParseUserPreferences();
+    const api = await requestMenuParse({
+      storageBucket: bucket,
+      storagePath,
+      userPreferences,
+    });
+
+    if (!api.ok) {
+      failAndHome('Could not parse menu', api.error);
+      return;
+    }
+
+    if (api.debug?.mock) {
+      failAndHome(
+        'Menu parser is in mock mode',
+        'The backend is returning demo menu data instead of your scanned menu. Disable MOCK_MENU_PARSE in backend/.env before testing real scans.',
+      );
+      return;
+    }
+
+    const validated = validateParsedMenu(api.menu);
+    if (!validated.ok) {
+      failAndHome('Invalid menu data', validated.error);
+      return;
+    }
+
+    if (!parsedMenuHasItems(validated.value)) {
+      failAndHome('Empty menu', 'No dishes were found. Try a clearer photo.');
+      return;
+    }
+
+    const persisted = await persistRestaurantMenuDraft(validated.value, restaurantId);
+    if (!persisted.ok) {
+      failAndHome('Save failed', persisted.error);
+      return;
+    }
+
+    await clearPendingRestaurantMenuScan();
+
+    router.replace({
+      pathname: '/restaurant-review-menu',
+      params: { scanId: persisted.scanId },
+    });
+  }, [bucket, failAndHome, storagePath, router]);
+
+  // Capture latest runPipeline via ref
+  const runPipelineRef = useRef(runPipeline);
+  runPipelineRef.current = runPipeline;
+
+  // Wait until route params include `storagePath` (avoid first-paint empty params).
+  useEffect(() => {
+    if (!storagePath.trim()) return;
+    let cancelled = false;
+    void runPipelineRef.current().catch((e) => {
+      if (!cancelled) {
+        failAndHome('Error', e instanceof Error ? e.message : 'Something went wrong.');
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [failAndHome, storagePath]);
+
+  const statusLabel = STATUS_MESSAGES[statusIndex];
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + 32, backgroundColor: Colors.background }]}>
+      <View style={styles.illustration}>
+        <RestaurantMenuProcessingIllustration />
+      </View>
+
+      <Text style={styles.title}>Processing your menu…</Text>
+      <Text style={styles.subtitle}>{"We're extracting your menu items using AI"}</Text>
+
+      <View style={styles.progressTrack}>
+        <Animated.View
+          style={[
+            styles.progressFill,
+            {
+              width: progressAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: ['0%', '100%'],
+              }),
+            },
+          ]}
+        >
+          <LinearGradient
+            colors={[t.primaryDark, t.primaryDark, t.primary, t.primary, t.primaryLight]}
+            start={{ x: 0, y: 0.5 }}
+            end={{ x: 1, y: 0.5 }}
+            style={styles.progressGradient}
+          />
+        </Animated.View>
+      </View>
+
+      <Text style={[styles.status, { color: t.primary }]}>{statusLabel}</Text>
+      <ActivityIndicator style={{ marginTop: Spacing.base }} color={t.primary} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+  },
+  illustration: {
+    alignItems: 'center',
+    width: 216,
+    height: 286,
+    marginTop: 28,
+    marginBottom: 28,
+  },
+  progressTrack: {
+    width: 240,
+    height: 6,
+    borderRadius: 9999,
+    backgroundColor: '#E5E7EB',
+    overflow: 'hidden',
+    marginBottom: Spacing.base,
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 9999,
+  },
+  progressGradient: {
+    width: '100%',
+    height: '100%',
+  },
+  title: {
+    fontSize: 28,
+    lineHeight: 42,
+    fontWeight: '700',
+    letterSpacing: 0.3828,
+    textAlign: 'center',
+    color: '#101828',
+    marginBottom: Spacing.sm,
+  },
+  subtitle: {
+    fontSize: 15,
+    lineHeight: 22,
+    fontWeight: '400',
+    letterSpacing: -0.2344,
+    textAlign: 'center',
+    color: '#4A5565',
+    marginBottom: Spacing.xl,
+    maxWidth: 280,
+  },
+  status: {
+    fontSize: 14,
+    lineHeight: 21,
+    fontWeight: '500',
+    letterSpacing: -0.1504,
+  },
+});
+

--- a/app/restaurant-menu.tsx
+++ b/app/restaurant-menu.tsx
@@ -1,30 +1,192 @@
-import { StyleSheet, Text } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Image, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { restaurantRoleTheme } from '@/constants/role-theme';
 import { RestaurantTabScreenLayout } from '@/components/RestaurantTabScreenLayout';
-import { Colors, Spacing, Typography } from '@/constants/theme';
+import { Colors, Typography } from '@/constants/theme';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+import { supabase } from '@/lib/supabase';
+import { fetchRestaurantMenuForScan } from '@/lib/restaurant-fetch-menu-for-scan';
+
+const t = restaurantRoleTheme;
 
 export default function RestaurantMenuScreen() {
   useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const params = useLocalSearchParams<{ published?: string }>();
+  const [loading, setLoading] = useState(true);
+  const [publishedScanId, setPublishedScanId] = useState<string | null>(null);
+  const [dishes, setDishes] = useState<Array<{ id: string; name: string; description: string | null; price_display: string | null; price_amount: number | null; image_url: string | null; spice_level: number; tags: string[] }>>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        setLoading(true);
+        const { data, error: userErr } = await supabase.auth.getUser();
+        const user = data?.user;
+        if (userErr) throw userErr;
+        if (!user) return;
+        const { data: restRow, error: restErr } = await supabase
+          .from('restaurants')
+          .select('published_menu_scan_id')
+          .eq('owner_id', user.id)
+          .maybeSingle();
+        if (restErr) throw restErr;
+
+        if (cancelled) return;
+        const scanId = restRow?.published_menu_scan_id ? String(restRow.published_menu_scan_id) : null;
+        setPublishedScanId(scanId);
+        if (scanId) {
+          const menu = await fetchRestaurantMenuForScan(scanId);
+          if (menu.ok && !cancelled) {
+            setDishes(
+              menu.dishes.map((d) => ({
+                id: d.id,
+                name: d.name,
+                description: d.description,
+                price_display: d.price_display,
+                price_amount: d.price_amount,
+                image_url: d.image_url,
+                spice_level: d.spice_level,
+                tags: d.tags,
+              })),
+            );
+          }
+        } else if (!cancelled) {
+          setDishes([]);
+        }
+      } catch {
+        // ignore for MVP
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const showLiveToast = params.published === '1';
+
+  const hasSpicy = (dish: { spice_level: number; tags: string[] }) =>
+    dish.spice_level > 0 || dish.tags.some((x) => x.trim().toLowerCase() === 'spicy');
+  const hasVegan = (dish: { tags: string[] }) =>
+    dish.tags.some((x) => ['vegan', 'vegetarian'].includes(x.trim().toLowerCase()));
+
+  if (showLiveToast) {
+    return (
+      <RestaurantTabScreenLayout activeTab="menu">
+        <View style={styles.liveRoot}>
+          <Text style={styles.liveTitle}>
+            Your menu is live <Text style={{ fontSize: 18 }}>🎉</Text>
+          </Text>
+          <PrimaryButton text="Continue" onPress={() => router.replace('/restaurant-menu')} accentColor={t.primary} accentShadowRgb={t.shadowRgb} />
+        </View>
+      </RestaurantTabScreenLayout>
+    );
+  }
 
   return (
     <RestaurantTabScreenLayout activeTab="menu">
-      <Text style={styles.title}>Menu</Text>
-      <Text style={styles.subtitle}>
-        Your published menu and categories will appear here after you upload.
-      </Text>
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>My Restaurant Menu</Text>
+        <Pressable accessibilityRole="button" accessibilityLabel="Add menu item" onPress={() => router.push('/restaurant-home')} style={({ pressed }) => [styles.plusBtn, pressed && { opacity: 0.9 }]}>
+          <MaterialCommunityIcons name="plus" size={18} color={Colors.white} />
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <View style={styles.centerBlock}>
+          <ActivityIndicator color={t.primary} />
+        </View>
+      ) : publishedScanId ? (
+        <ScrollView contentContainerStyle={styles.list}>
+          {dishes.map((dish) => {
+            const price = dish.price_display?.trim() || (dish.price_amount == null ? '—' : String(dish.price_amount));
+            return (
+              <View key={dish.id} style={[styles.card, { borderColor: '#E5E7EB' }]}>
+                <View style={styles.cardRow}>
+                  {dish.image_url ? (
+                    <Image source={{ uri: dish.image_url }} style={styles.imagePlaceholder} />
+                  ) : (
+                    <View style={styles.imagePlaceholder}>
+                      <MaterialCommunityIcons name="silverware-fork-knife" size={22} color={Colors.textPlaceholder} />
+                    </View>
+                  )}
+                  <View style={styles.cardTextCol}>
+                    <View style={styles.namePriceRow}>
+                      <Text style={styles.dishName} numberOfLines={1}>
+                        {dish.name}
+                      </Text>
+                      <Text style={styles.dishPrice}>{price}</Text>
+                      <MaterialCommunityIcons name="dots-vertical" size={18} color={Colors.textSecondary} />
+                    </View>
+                    <Text style={styles.dishDesc} numberOfLines={2}>
+                      {dish.description || '—'}
+                    </Text>
+
+                    <View style={styles.chipsRow}>
+                      {hasVegan(dish) ? (
+                        <View style={[styles.chip, { borderColor: t.primaryLight }]}>
+                          <MaterialCommunityIcons name="leaf" size={14} color={t.primary} />
+                          <Text style={styles.chipText}>Vegan</Text>
+                        </View>
+                      ) : null}
+                      {hasSpicy(dish) ? (
+                        <View style={[styles.chip, { borderColor: t.primaryLight }]}>
+                          <MaterialCommunityIcons name="fire" size={14} color={t.primary} />
+                          <Text style={styles.chipText}>Spicy</Text>
+                        </View>
+                      ) : null}
+                    </View>
+                  </View>
+                </View>
+              </View>
+            );
+          })}
+        </ScrollView>
+      ) : (
+        <View style={styles.emptyRoot}>
+          <Text style={styles.emptyTitle}>No published menu yet</Text>
+          <Text style={styles.emptySubtitle}>Upload and publish a menu to make it live for customers.</Text>
+          <PrimaryButton text="Upload menu" onPress={() => router.push('/restaurant-home')} accentColor={t.primary} accentShadowRgb={t.shadowRgb} />
+        </View>
+      )}
     </RestaurantTabScreenLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  title: {
-    ...Typography.heading,
-    color: Colors.text,
-    marginBottom: Spacing.sm,
+  liveRoot: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 18 },
+  liveTitle: { ...Typography.heading, textAlign: 'center' as const, color: Colors.text, marginBottom: 8 },
+  headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingTop: 12, paddingBottom: 6 },
+  headerTitle: { ...Typography.headingSmall, fontWeight: '800', color: Colors.text },
+  plusBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 999,
+    backgroundColor: t.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  subtitle: {
-    ...Typography.body,
-    color: Colors.textSecondary,
-  },
+  centerBlock: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  list: { paddingHorizontal: 16, paddingBottom: 120, gap: 12 },
+  card: { backgroundColor: Colors.white, borderWidth: 1, borderRadius: 16, padding: 12 },
+  cardRow: { flexDirection: 'row', gap: 12 },
+  imagePlaceholder: { width: 56, height: 56, borderRadius: 14, backgroundColor: '#F3F4F6', alignItems: 'center', justifyContent: 'center' },
+  cardTextCol: { flex: 1, minWidth: 0 },
+  namePriceRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  dishName: { ...Typography.bodyMedium, fontWeight: '800', color: Colors.text, flex: 1 },
+  dishPrice: { ...Typography.bodyMedium, fontWeight: '800', color: Colors.textSecondary },
+  dishDesc: { ...Typography.body, color: Colors.textSecondary, marginTop: 4 },
+  chipsRow: { flexDirection: 'row', gap: 8, flexWrap: 'wrap', marginTop: 8 },
+  chip: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999 },
+  chipText: { ...Typography.captionMedium, fontWeight: '800', color: t.primary },
+  emptyRoot: { flex: 1, paddingHorizontal: 16, justifyContent: 'center', gap: 12, alignItems: 'center' },
+  emptyTitle: { ...Typography.headingSmall, fontWeight: '800', color: Colors.text, textAlign: 'center' as const },
+  emptySubtitle: { ...Typography.body, color: Colors.textSecondary, textAlign: 'center' as const },
 });

--- a/app/restaurant-review-menu.tsx
+++ b/app/restaurant-review-menu.tsx
@@ -1,0 +1,777 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Image } from 'expo-image';
+import {
+  ActivityIndicator,
+  Alert,
+  Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { restaurantRoleTheme } from '@/constants/role-theme';
+import { Colors, Typography } from '@/constants/theme';
+import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+import { fetchRestaurantMenuForScan, type RestaurantMenuDishRow } from '@/lib/restaurant-fetch-menu-for-scan';
+import { publishRestaurantMenu } from '@/lib/restaurant-publish-menu';
+import { updateRestaurantMenuScanName } from '@/lib/restaurant-rename-menu-scan';
+
+const t = restaurantRoleTheme;
+
+const cardShadow = Platform.select({
+  ios: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+  },
+  android: { elevation: 2 },
+  default: {},
+});
+
+const footerShadow = Platform.select({
+  ios: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 20,
+  },
+  android: { elevation: 12 },
+  default: {},
+});
+
+const publishGradientColors = ['#047857', '#059669', '#10B981', '#34D399'] as const;
+
+function titleize(s: string): string {
+  return s
+    .split(/[\s-]+/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function tagChip(tag: string) {
+  const lower = tag.trim().toLowerCase();
+  if (lower === 'spicy' || lower === 'medium' || lower === 'mild') return { icon: 'fire', label: titleize(tag) };
+  if (lower === 'vegan' || lower === 'vegetarian') return { icon: 'leaf', label: titleize(tag) };
+  return { icon: 'tag', label: tag };
+}
+
+function buildNeedsReviewCounts(dishes: RestaurantMenuDishRow[]) {
+  const total = dishes.length;
+  const needReview = dishes.filter((d) => d.needs_review).length;
+  return { total, needReview, reviewed: total - needReview };
+}
+
+function spiceLevelLabel(level: 0 | 1 | 2 | 3): string {
+  if (level === 1) return 'Mild';
+  if (level === 2) return 'Medium';
+  if (level === 3) return 'Spicy';
+  return 'None';
+}
+
+export default function RestaurantReviewMenuScreen() {
+  useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ scanId?: string | string[] }>();
+
+  const scanIdRaw = params.scanId;
+  const scanId = Array.isArray(scanIdRaw) ? scanIdRaw[0] : scanIdRaw;
+
+  const [loading, setLoading] = useState(Boolean(scanId));
+  const [error, setError] = useState<string | null>(null);
+  const [restaurantName, setRestaurantName] = useState<string>('Menu');
+  const [dishes, setDishes] = useState<RestaurantMenuDishRow[]>([]);
+  const [defaultSectionId, setDefaultSectionId] = useState<string | null>(null);
+
+  const [renameModalVisible, setRenameModalVisible] = useState(false);
+  const [renameInput, setRenameInput] = useState('');
+  const [renameSaving, setRenameSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!scanId) return;
+    setLoading(true);
+    setError(null);
+    const result = await fetchRestaurantMenuForScan(scanId);
+    if (!result.ok) {
+      setError(result.error);
+      setDishes([]);
+      setDefaultSectionId(null);
+      setLoading(false);
+      return;
+    }
+
+    setRestaurantName(result.scan.restaurant_name?.trim() || 'Menu');
+    const flat = [...result.dishes].sort((a, b) => a.sort_order - b.sort_order);
+    setDishes(flat);
+    setDefaultSectionId(result.sections[0]?.id ?? null);
+    setLoading(false);
+  }, [scanId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const counts = useMemo(() => buildNeedsReviewCounts(dishes), [dishes]);
+
+  const runPublish = useCallback(async () => {
+    if (!scanId) return;
+    const res = await publishRestaurantMenu(scanId);
+    if (!res.ok) {
+      Alert.alert('Publish failed', res.error);
+      return;
+    }
+    router.replace({ pathname: '/restaurant-menu', params: { published: '1' } });
+  }, [router, scanId]);
+
+  const onPublish = useCallback(() => {
+    if (!scanId) return;
+    if (counts.needReview > 0) {
+      const n = counts.needReview;
+      Alert.alert(
+        'Some dishes still need review',
+        `${n} item(s) are marked as needing review. You can publish anyway, or go back and edit dishes first.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Publish anyway', onPress: () => void runPublish() },
+        ],
+      );
+      return;
+    }
+    void runPublish();
+  }, [counts.needReview, runPublish, scanId]);
+
+  const onAddMissingItem = useCallback(() => {
+    if (!scanId) return;
+    if (!defaultSectionId) {
+      Alert.alert('Missing section', 'Could not determine a section to add the dish.');
+      return;
+    }
+    router.push({ pathname: '/restaurant-add-dish', params: { scanId, sectionId: defaultSectionId } });
+  }, [defaultSectionId, router, scanId]);
+
+  const onEditDish = useCallback(
+    (dishId: string) => {
+      router.push({ pathname: '/restaurant-edit-dish/[dishId]', params: { dishId, scanId } });
+    },
+    [router, scanId],
+  );
+
+  const openRenameMenu = useCallback(() => {
+    setRenameInput(restaurantName);
+    setRenameModalVisible(true);
+  }, [restaurantName]);
+
+  const onConfirmRenameMenu = useCallback(async () => {
+    if (!scanId) return;
+    setRenameSaving(true);
+    try {
+      const res = await updateRestaurantMenuScanName(scanId, renameInput);
+      if (!res.ok) {
+        Alert.alert('Could not rename', res.error);
+        return;
+      }
+      const next = renameInput.trim() || 'Menu';
+      setRestaurantName(next);
+      Keyboard.dismiss();
+      setRenameModalVisible(false);
+    } finally {
+      setRenameSaving(false);
+    }
+  }, [renameInput, scanId]);
+
+  const reviewProgress = counts.total > 0 ? counts.reviewed / counts.total : 0;
+
+  return (
+    <View style={styles.root}>
+      <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
+        <View style={styles.headerTopRow}>
+          <Pressable accessibilityRole="button" accessibilityLabel="Back" onPress={() => router.back()} style={({ pressed }) => [styles.iconBtn, pressed && styles.iconBtnPressed]}>
+            <MaterialCommunityIcons name="arrow-left" size={24} color={Colors.text} />
+          </Pressable>
+          <View style={styles.titleSlot}>
+            <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+              {restaurantName}
+            </Text>
+            {!loading && !error && scanId ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Rename menu"
+                hitSlop={10}
+                onPress={openRenameMenu}
+                style={({ pressed }) => [styles.titlePencilBtn, pressed && { opacity: 0.7 }]}
+              >
+                <MaterialCommunityIcons name="pencil" size={16} color="#99A1AF" />
+              </Pressable>
+            ) : null}
+          </View>
+          <View style={styles.iconBtn}>
+            <MaterialCommunityIcons name="menu" size={20} color={Colors.text} />
+          </View>
+        </View>
+
+        {!loading && !error ? (
+          <View style={styles.headerStatsRow}>
+            <Text style={styles.headerStatMuted}>{`${dishes.length} items extracted`}</Text>
+            <Text style={styles.headerStatBullet}> • </Text>
+            <Text style={styles.headerStatAccent}>
+              {counts.needReview === 1 ? '1 need review' : `${counts.needReview} need review`}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      {loading ? (
+        <View style={[styles.centerBlock, { paddingTop: 60 }]}>
+          <ActivityIndicator color={t.primary} />
+          <Text style={{ marginTop: 12, ...Typography.body, color: Colors.textSecondary }}>Loading menu…</Text>
+        </View>
+      ) : error ? (
+        <View style={[styles.centerBlock, { paddingTop: 60 }]}>
+          <Text style={{ ...Typography.body, color: Colors.error, textAlign: 'center' }}>{error}</Text>
+        </View>
+      ) : (
+        <>
+          <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+            <View style={styles.list}>
+              {dishes.map((dish) => {
+                const priceLine = dish.price_display?.trim() || (dish.price_amount === null ? '—' : String(dish.price_amount));
+                return (
+                  <Pressable
+                    key={dish.id}
+                    accessibilityRole="button"
+                    onPress={() => onEditDish(dish.id)}
+                    style={({ pressed }) => [
+                      styles.card,
+                      cardShadow,
+                      dish.needs_review ? styles.cardNeedsReview : null,
+                      pressed && { opacity: 0.92 },
+                    ]}
+                  >
+                    <View style={styles.cardInner}>
+                      <View style={styles.cardRow}>
+                        {dish.image_url ? (
+                          <Image source={{ uri: dish.image_url }} style={styles.dishImage} contentFit="cover" />
+                        ) : (
+                          <View style={styles.imagePlaceholder}>
+                            <MaterialCommunityIcons name="image-outline" size={20} color="#D1D5DC" />
+                          </View>
+                        )}
+
+                        <View style={styles.cardTextCol}>
+                          <View style={styles.namePriceRow}>
+                            <Text style={styles.dishName} numberOfLines={2}>
+                              {dish.name}
+                            </Text>
+                            <Text style={styles.dishPrice}>{priceLine}</Text>
+                          </View>
+                          <Text style={styles.dishDesc} numberOfLines={3}>
+                            {dish.description || '—'}
+                          </Text>
+
+                          <View style={styles.chipsRow}>
+                            {dish.spice_level > 0 ? (
+                              <View style={styles.chipNeutral}>
+                                <Text style={styles.chipNeutralEmoji}>🌶</Text>
+                                <Text style={styles.chipNeutralText}>{spiceLevelLabel(dish.spice_level)}</Text>
+                              </View>
+                            ) : null}
+
+                            {dish.needs_review ? (
+                              <View style={styles.chipNeedReview}>
+                                <MaterialCommunityIcons name="alert-circle-outline" size={12} color={t.primaryDark} />
+                                <Text style={styles.chipNeedReviewText}>Needs review</Text>
+                              </View>
+                            ) : null}
+
+                            {dish.tags?.length
+                              ? dish.tags.slice(0, 3).map((tag) => {
+                                  const chip = tagChip(tag);
+                                  return (
+                                    <View key={tag} style={styles.chipNeutral}>
+                                      {chip.icon === 'fire' ? (
+                                        <Text style={styles.chipNeutralEmoji}>🌶</Text>
+                                      ) : chip.icon === 'leaf' ? (
+                                        <Text style={styles.chipNeutralEmoji}>🌱</Text>
+                                      ) : (
+                                        <MaterialCommunityIcons name="tag-outline" size={12} color="#4A5565" />
+                                      )}
+                                      <Text style={styles.chipNeutralText}>{chip.label}</Text>
+                                    </View>
+                                  );
+                                })
+                              : null}
+                          </View>
+                        </View>
+                      </View>
+
+                      <View style={styles.menuDots} pointerEvents="none">
+                        <MaterialCommunityIcons name="dots-vertical" size={20} color="#99A1AF" />
+                      </View>
+                    </View>
+                  </Pressable>
+                );
+              })}
+
+              <Pressable accessibilityRole="button" onPress={onAddMissingItem} style={({ pressed }) => [styles.addMissingCard, pressed && { opacity: 0.92 }]}>
+                <MaterialCommunityIcons name="plus" size={20} color="#99A1AF" />
+                <Text style={styles.addMissingText}>Add missing item</Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+
+          <View style={[styles.footer, footerShadow, { paddingBottom: Math.max(insets.bottom, 12) }]}>
+            <View style={styles.footerCounts}>
+              <Text style={styles.footerLeft}>{`${counts.reviewed} / ${counts.total} items reviewed`}</Text>
+              <Text style={styles.footerRight}>
+                {counts.needReview === 1 ? '1 need review' : `${counts.needReview} need review`}
+              </Text>
+            </View>
+            <View style={styles.progressTrack}>
+              <LinearGradient
+                colors={[...publishGradientColors]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={[styles.progressFill, { width: `${Math.round(reviewProgress * 100)}%` }]}
+              />
+            </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Publish Menu"
+              onPress={() => void onPublish()}
+              style={({ pressed }) => [styles.publishWrap, pressed && { opacity: 0.92 }]}
+            >
+              <LinearGradient colors={[...publishGradientColors]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} style={styles.publishGradient}>
+                <Text style={styles.publishBtnText}>Publish Menu</Text>
+              </LinearGradient>
+            </Pressable>
+          </View>
+        </>
+      )}
+
+      <Modal visible={renameModalVisible} animationType="fade" transparent onRequestClose={() => !renameSaving && setRenameModalVisible(false)}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.modalRoot}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Dismiss"
+            disabled={renameSaving}
+            onPress={() => {
+              Keyboard.dismiss();
+              if (!renameSaving) setRenameModalVisible(false);
+            }}
+            style={StyleSheet.absoluteFillObject}
+          />
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>Rename menu</Text>
+            <TextInput
+              value={renameInput}
+              onChangeText={setRenameInput}
+              placeholder="Menu name"
+              placeholderTextColor="#6A7282"
+              style={styles.modalInput}
+              autoCapitalize="words"
+              autoCorrect
+              editable={!renameSaving}
+              maxLength={120}
+              returnKeyType="done"
+              onSubmitEditing={() => void onConfirmRenameMenu()}
+            />
+            <View style={styles.modalActions}>
+              <Pressable
+                onPress={() => {
+                  Keyboard.dismiss();
+                  if (!renameSaving) setRenameModalVisible(false);
+                }}
+                disabled={renameSaving}
+                style={({ pressed }) => [styles.modalBtnSecondary, pressed && { opacity: 0.85 }]}
+              >
+                <Text style={styles.modalBtnSecondaryText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => void onConfirmRenameMenu()}
+                disabled={renameSaving}
+                style={({ pressed }) => [
+                  styles.modalBtnPrimary,
+                  { backgroundColor: t.primary },
+                  pressed && { opacity: 0.92 },
+                  renameSaving && { opacity: 0.7 },
+                ]}
+              >
+                {renameSaving ? (
+                  <ActivityIndicator color={Colors.white} />
+                ) : (
+                  <Text style={styles.modalBtnPrimaryText}>Save</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: Colors.white,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingBottom: 1,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+    backgroundColor: Colors.white,
+    gap: 24,
+  },
+  headerTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 44,
+  },
+  iconBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 9999,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+  },
+  iconBtnPressed: { opacity: 0.85 },
+  titleSlot: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    gap: 2,
+  },
+  titlePencilBtn: {
+    padding: 4,
+    marginLeft: 2,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    lineHeight: 30,
+    letterSpacing: -0.45,
+    color: Colors.text,
+    textAlign: 'center',
+    flexShrink: 1,
+    maxWidth: 200,
+  },
+  modalRoot: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(15, 24, 40, 0.45)',
+  },
+  modalCard: {
+    width: '88%',
+    maxWidth: 340,
+    zIndex: 1,
+    padding: 20,
+    borderRadius: 16,
+    backgroundColor: Colors.white,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.text,
+    marginBottom: 12,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderColor: '#D1D5DC',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: Colors.text,
+    marginBottom: 18,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 12,
+    alignItems: 'center',
+  },
+  modalBtnSecondary: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+  },
+  modalBtnSecondaryText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#6A7282',
+  },
+  modalBtnPrimary: {
+    minWidth: 88,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalBtnPrimaryText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.white,
+  },
+  headerStatsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingBottom: 8,
+  },
+  headerStatMuted: {
+    fontSize: 13,
+    lineHeight: 20,
+    letterSpacing: -0.076,
+    color: '#6A7282',
+  },
+  headerStatBullet: {
+    fontSize: 13,
+    lineHeight: 20,
+    letterSpacing: -0.076,
+    color: '#6A7282',
+  },
+  headerStatAccent: {
+    fontSize: 13,
+    lineHeight: 20,
+    letterSpacing: -0.076,
+    color: t.primaryDark,
+    fontWeight: '500',
+  },
+  scroll: { flex: 1 },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 200,
+  },
+  centerBlock: { alignItems: 'center' },
+  list: {
+    gap: 16,
+  },
+  card: {
+    borderRadius: 16,
+    backgroundColor: Colors.white,
+    overflow: 'visible',
+  },
+  cardNeedsReview: {
+    backgroundColor: 'rgba(236, 253, 245, 0.45)',
+    borderWidth: 1,
+    borderColor: t.cardAccentBorder,
+  },
+  cardInner: {
+    position: 'relative',
+    padding: 16,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 16,
+  },
+  dishImage: {
+    width: 120,
+    height: 80,
+    borderRadius: 14,
+    backgroundColor: '#F9FAFB',
+    flexShrink: 0,
+  },
+  imagePlaceholder: {
+    width: 64,
+    height: 64,
+    borderRadius: 14,
+    backgroundColor: 'rgba(249, 250, 251, 0.9)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  cardTextCol: { flex: 1, minWidth: 0, paddingRight: 28 },
+  namePriceRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  dishName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '700',
+    lineHeight: 20,
+    letterSpacing: -0.31,
+    color: Colors.text,
+  },
+  dishPrice: {
+    fontSize: 16,
+    fontWeight: '700',
+    lineHeight: 24,
+    letterSpacing: -0.31,
+    color: Colors.text,
+    flexShrink: 0,
+    marginLeft: 4,
+  },
+  dishDesc: {
+    marginTop: 8,
+    fontSize: 13,
+    lineHeight: 21,
+    letterSpacing: -0.076,
+    color: '#6A7282',
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 10,
+  },
+  chipNeutral: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 9999,
+    backgroundColor: '#F3F4F6',
+  },
+  chipNeutralEmoji: {
+    fontSize: 11,
+    lineHeight: 16,
+  },
+  chipNeutralText: {
+    fontSize: 11,
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    fontWeight: '500',
+    color: '#4A5565',
+  },
+  chipNeedReview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 9999,
+    backgroundColor: t.primaryLight,
+    borderWidth: 1,
+    borderColor: t.cardAccentBorder,
+  },
+  chipNeedReviewText: {
+    fontSize: 11,
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    fontWeight: '500',
+    color: t.primaryDark,
+  },
+  menuDots: {
+    position: 'absolute',
+    right: 10,
+    top: 14,
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addMissingCard: {
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: '#E5E7EB',
+    borderRadius: 14,
+    height: 58,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    backgroundColor: Colors.white,
+  },
+  addMissingText: {
+    fontSize: 15,
+    lineHeight: 22,
+    letterSpacing: -0.23,
+    fontWeight: '500',
+    color: '#99A1AF',
+  },
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    backgroundColor: Colors.white,
+    gap: 8,
+  },
+  footerCounts: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  footerLeft: {
+    fontSize: 11,
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    color: '#6A7282',
+  },
+  footerRight: {
+    fontSize: 11,
+    lineHeight: 16,
+    letterSpacing: 0.064,
+    color: t.primaryDark,
+    fontWeight: '500',
+  },
+  progressTrack: {
+    height: 2,
+    borderRadius: 9999,
+    backgroundColor: '#F3F4F6',
+    overflow: 'hidden',
+    width: '100%',
+  },
+  progressFill: {
+    height: 2,
+    borderRadius: 9999,
+  },
+  publishWrap: {
+    borderRadius: 14,
+    overflow: 'hidden',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.1,
+        shadowRadius: 6,
+      },
+      android: { elevation: 4 },
+      default: {},
+    }),
+  },
+  publishGradient: {
+    height: 46,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  publishBtnText: {
+    fontSize: 15,
+    lineHeight: 22,
+    letterSpacing: -0.23,
+    fontWeight: '600',
+    color: Colors.white,
+  },
+});
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -399,6 +399,207 @@ def create_app() -> Flask:
                 traceback.print_exc(file=sys.stderr)
             return jsonify({"ok": False, "error": f"image_generation_failed: {e!s}"}), 502
 
+    @app.post("/v1/restaurant-dishes/<dish_id>/generate-image")
+    def generate_restaurant_dish_image(dish_id: str):
+        payload = None
+        if REQUIRE_AUTH:
+            payload = verify_bearer_token(request.headers.get("Authorization"))
+            if payload is None:
+                return auth_error_response()
+
+        from storage_supabase import (
+            get_supabase_admin,
+            storage_object_exists,
+            upload_storage_object,
+        )
+
+        from image_generate_vertex import build_dish_image_prompt, generate_dish_image_bytes
+
+        client = get_supabase_admin()
+
+        try:
+            dish_res = (
+                client.table("restaurant_menu_dishes")
+                .select("id, section_id, name, description, ingredients, image_url")
+                .eq("id", dish_id)
+                .limit(1)
+                .execute()
+            )
+            dish_rows = getattr(dish_res, "data", None) or []
+            if not dish_rows:
+                return jsonify({"ok": False, "error": "dish not found"}), 404
+            dish = dish_rows[0]
+
+            sec_res = (
+                client.table("restaurant_menu_sections")
+                .select("id, scan_id")
+                .eq("id", dish["section_id"])
+                .limit(1)
+                .execute()
+            )
+            sec_rows = getattr(sec_res, "data", None) or []
+            if not sec_rows:
+                return jsonify({"ok": False, "error": "dish section not found"}), 404
+            section = sec_rows[0]
+
+            scan_res = (
+                client.table("restaurant_menu_scans")
+                .select("id, restaurant_id, restaurant_name")
+                .eq("id", section["scan_id"])
+                .limit(1)
+                .execute()
+            )
+            scan_rows = getattr(scan_res, "data", None) or []
+            if not scan_rows:
+                return jsonify({"ok": False, "error": "scan not found"}), 404
+            scan = scan_rows[0]
+
+            if payload is not None:
+                rest_res = (
+                    client.table("restaurants")
+                    .select("owner_id")
+                    .eq("id", scan["restaurant_id"])
+                    .limit(1)
+                    .execute()
+                )
+                rest_rows = getattr(rest_res, "data", None) or []
+                if not rest_rows or rest_rows[0].get("owner_id") != payload.get("sub"):
+                    return jsonify({"ok": False, "error": "unauthorized"}), 401
+
+            existing_url = (dish.get("image_url") or "").strip()
+            if existing_url:
+                return jsonify({"ok": True, "image_url": existing_url, "cached": True}), 200
+
+            storage_path = f"{dish_id}.png"
+            public_url = client.storage.from_(DISH_IMAGES_BUCKET).get_public_url(storage_path)
+
+            if storage_object_exists(DISH_IMAGES_BUCKET, storage_path):
+                (
+                    client.table("restaurant_menu_dishes")
+                    .update({"image_url": public_url})
+                    .eq("id", dish_id)
+                    .execute()
+                )
+                return jsonify({"ok": True, "image_url": public_url, "cached": True}), 200
+
+            ingredients = dish.get("ingredients")
+            if not isinstance(ingredients, list):
+                ingredients = []
+
+            prompt = build_dish_image_prompt(
+                dish_name=(dish.get("name") or "Dish").strip(),
+                description=dish.get("description"),
+                ingredients=[str(item) for item in ingredients if isinstance(item, str)],
+                restaurant_name=scan.get("restaurant_name"),
+            )
+            image_bytes = generate_dish_image_bytes(prompt)
+            public_url = upload_storage_object(
+                DISH_IMAGES_BUCKET,
+                storage_path,
+                image_bytes,
+                content_type="image/png",
+                upsert=True,
+            )
+
+            (
+                client.table("restaurant_menu_dishes")
+                .update({"image_url": public_url})
+                .eq("id", dish_id)
+                .execute()
+            )
+
+            return jsonify({"ok": True, "image_url": public_url, "cached": False}), 200
+        except Exception as e:
+            if _is_flask_debug(app):
+                traceback.print_exc(file=sys.stderr)
+            return jsonify({"ok": False, "error": f"image_generation_failed: {e!s}"}), 502
+
+    @app.post("/v1/restaurant-dishes/<dish_id>/generate-summary")
+    def generate_restaurant_dish_summary(dish_id: str):
+        payload = None
+        if REQUIRE_AUTH:
+            payload = verify_bearer_token(request.headers.get("Authorization"))
+            if payload is None:
+                return auth_error_response()
+
+        from llm_dish_vertex import generate_dish_description
+        from storage_supabase import get_supabase_admin
+
+        client = get_supabase_admin()
+
+        try:
+            dish_res = (
+                client.table("restaurant_menu_dishes")
+                .select("id, section_id, name, description, ingredients")
+                .eq("id", dish_id)
+                .limit(1)
+                .execute()
+            )
+            dish_rows = getattr(dish_res, "data", None) or []
+            if not dish_rows:
+                return jsonify({"ok": False, "error": "dish not found"}), 404
+            dish = dish_rows[0]
+
+            sec_res = (
+                client.table("restaurant_menu_sections")
+                .select("id, scan_id")
+                .eq("id", dish["section_id"])
+                .limit(1)
+                .execute()
+            )
+            sec_rows = getattr(sec_res, "data", None) or []
+            if not sec_rows:
+                return jsonify({"ok": False, "error": "dish section not found"}), 404
+            section = sec_rows[0]
+
+            scan_res = (
+                client.table("restaurant_menu_scans")
+                .select("id, restaurant_id, restaurant_name")
+                .eq("id", section["scan_id"])
+                .limit(1)
+                .execute()
+            )
+            scan_rows = getattr(scan_res, "data", None) or []
+            if not scan_rows:
+                return jsonify({"ok": False, "error": "scan not found"}), 404
+            scan = scan_rows[0]
+
+            if payload is not None:
+                rest_res = (
+                    client.table("restaurants")
+                    .select("owner_id")
+                    .eq("id", scan["restaurant_id"])
+                    .limit(1)
+                    .execute()
+                )
+                rest_rows = getattr(rest_res, "data", None) or []
+                if not rest_rows or rest_rows[0].get("owner_id") != payload.get("sub"):
+                    return jsonify({"ok": False, "error": "unauthorized"}), 401
+
+            ingredients = dish.get("ingredients")
+            if not isinstance(ingredients, list):
+                ingredients = []
+
+            desc = generate_dish_description(
+                dish_name=(dish.get("name") or "Dish").strip(),
+                ingredients=[str(item) for item in ingredients if isinstance(item, str)],
+                restaurant_name=scan.get("restaurant_name"),
+                debug_llm=_is_flask_debug(app),
+            )
+
+            (
+                client.table("restaurant_menu_dishes")
+                .update({"description": desc})
+                .eq("id", dish_id)
+                .execute()
+            )
+
+            return jsonify({"ok": True, "description": desc}), 200
+        except Exception as e:
+            if _is_flask_debug(app):
+                traceback.print_exc(file=sys.stderr)
+            return jsonify({"ok": False, "error": f"summary_generation_failed: {e!s}"}), 502
+
     return app
 
 

--- a/backend/llm_dish_vertex.py
+++ b/backend/llm_dish_vertex.py
@@ -1,0 +1,123 @@
+"""
+Vertex AI Gemini: generate a concise dish description (summary) for
+restaurant menu editing.
+
+Returns JSON:
+  { "description": string | null }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Sequence
+
+_vertex_initialized = False
+
+
+def _ensure_vertex() -> None:
+    global _vertex_initialized
+    if _vertex_initialized:
+        return
+    project = os.getenv("GCP_PROJECT", "").strip()
+    if not project:
+        raise RuntimeError("GCP_PROJECT must be set for Vertex AI dish summary generation")
+    location = os.getenv("VERTEX_LOCATION", "us-central1").strip()
+    import vertexai
+
+    vertexai.init(project=project, location=location)
+    _vertex_initialized = True
+
+
+def _model_name() -> str:
+    return os.getenv("GEMINI_MODEL", "gemini-2.0-flash-001").strip() or "gemini-2.0-flash-001"
+
+
+def _json_from_model_text(text: str) -> Any:
+    """
+    Parse model output; strip ```json fences if present.
+    (Mirrors llm_menu_vertex behavior so parsing is consistent.)
+    """
+    t = text.strip()
+    m = re.match(r"^```(?:json)?\s*\n?(.*)\n?```\s*$", t, re.DOTALL | re.IGNORECASE)
+    if m:
+        t = m.group(1).strip()
+    return json.loads(t)
+
+
+SYSTEM_INSTRUCTION = """You are PickMyPlate's menu assistant.
+Given a dish's name, ingredients, and optional restaurant context, write ONE short summary (1–2 sentences).
+
+Hard rules:
+1. Output a single JSON object only (no markdown, no extra text).
+2. JSON shape must be:
+   { "description": string | null }
+3. description:
+   - If you can infer something plausible from the inputs, write a concise 1–2 sentence description.
+   - If inputs are too empty/unclear, use null.
+4. Do not include disclaimers or repeated boilerplate.
+5. Keep it natural for a menu detail screen.
+"""
+
+
+def generate_dish_description(
+    *,
+    dish_name: str,
+    ingredients: Sequence[str] | None,
+    restaurant_name: str | None,
+    debug_llm: bool = False,
+) -> str | None:
+    """
+    Generates and returns description text (or None).
+    Raises RuntimeError on invalid model output.
+    """
+    _ensure_vertex()
+
+    from vertexai.generative_models import GenerationConfig, GenerativeModel
+
+    model = GenerativeModel(_model_name(), system_instruction=SYSTEM_INSTRUCTION)
+    gen_cfg = GenerationConfig(
+        temperature=0.3,
+        response_mime_type="application/json",
+    )
+
+    ing_list: list[str] = []
+    if ingredients:
+        ing_list = [str(x).strip() for x in ingredients if isinstance(x, str) and str(x).strip()]
+
+    parts: list[str] = [
+        f"Dish name: {dish_name or '(unknown)'}.",
+        f"Restaurant context: {restaurant_name or '(unknown)'}.",
+    ]
+    if ing_list:
+        parts.append(f"Ingredients: {', '.join(ing_list[:12])}.")
+    else:
+        parts.append("Ingredients: (unknown).")
+
+    user_message = "\n".join(parts)
+    response = model.generate_content(user_message, generation_config=gen_cfg)
+    if not response.candidates:
+        raise RuntimeError("Gemini returned no candidates")
+
+    text = response.text or ""
+    if not text.strip():
+        raise RuntimeError("Gemini returned empty text")
+
+    parsed = _json_from_model_text(text)
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Gemini JSON root must be an object")
+
+    desc = parsed.get("description")
+    if desc is None:
+        return None
+    if isinstance(desc, str):
+        s = desc.strip()
+        return s if s else None
+
+    if debug_llm:
+        # eslint-style: keep backend simple; no print if not debug
+        pass
+
+    return None
+

--- a/components/RestaurantMenuProcessingIllustration.tsx
+++ b/components/RestaurantMenuProcessingIllustration.tsx
@@ -1,0 +1,82 @@
+import { SvgXml } from 'react-native-svg';
+
+/**
+ * Restaurant menu scan processing illustration (216×286).
+ * Green theme aligned with restaurantRoleTheme; structure matches original orange asset.
+ */
+const MENU_PROCESSING_ILLUSTRATION_XML = `
+<svg width="216" height="286" viewBox="0 0 216 286" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.500293">
+<path d="M68 146C68 144.895 68.8954 144 70 144H126C127.105 144 128 144.895 128 146C128 147.105 127.105 148 126 148H70C68.8954 148 68 147.105 68 146Z" fill="#059669"/>
+</g>
+<g opacity="0.550828">
+<path d="M68 154C68 152.895 68.8954 152 70 152H146C147.105 152 148 152.895 148 154C148 155.105 147.105 156 146 156H70C68.8954 156 68 155.105 68 154Z" fill="#34D399"/>
+</g>
+<g opacity="0.681649">
+<path d="M68 162C68 160.895 68.8954 160 70 160H136C137.105 160 138 160.895 138 162C138 163.105 137.105 164 136 164H70C68.8954 164 68 163.105 68 162Z" fill="#A7F3D0"/>
+</g>
+<g filter="url(#rmproc_filter_dd)">
+<mask id="rmproc_mask_inside" fill="white">
+<path d="M12 196C12 187.163 19.1634 180 28 180H188C196.837 180 204 187.163 204 196V248C204 256.837 196.837 264 188 264H28C19.1634 264 12 256.837 12 248V196Z"/>
+</mask>
+<path d="M12 196C12 187.163 19.1634 180 28 180H188C196.837 180 204 187.163 204 196V248C204 256.837 196.837 264 188 264H28C19.1634 264 12 256.837 12 248V196Z" fill="white" shape-rendering="crispEdges"/>
+<path d="M28 180V182H188V180V178H28V180ZM204 196H202V248H204H206V196H204ZM188 264V262H28V264V266H188V264ZM12 248H14V196H12H10V248H12ZM28 264V262C20.268 262 14 255.732 14 248H12H10C10 257.941 18.0589 266 28 266V264ZM204 248H202C202 255.732 195.732 262 188 262V264V266C197.941 266 206 257.941 206 248H204ZM188 180V182C195.732 182 202 188.268 202 196H204H206C206 186.059 197.941 178 188 178V180ZM28 180V178C18.0589 178 10 186.059 10 196H12H14C14 188.268 20.268 182 28 182V180Z" fill="#D1FAE5" mask="url(#rmproc_mask_inside)"/>
+<g opacity="0.500293">
+<path d="M30 202C30 199.791 31.7909 198 34 198C36.2091 198 38 199.791 38 202C38 204.209 36.2091 206 34 206C31.7909 206 30 204.209 30 202Z" fill="#059669"/>
+</g>
+<g opacity="0.500293">
+<path d="M46 202C46 199.791 47.7909 198 50 198H182C184.209 198 186 199.791 186 202C186 204.209 184.209 206 182 206H50C47.7909 206 46 204.209 46 202Z" fill="#E5E7EB"/>
+</g>
+<g opacity="0.550828">
+<path d="M30 222C30 219.791 31.7909 218 34 218C36.2091 218 38 219.791 38 222C38 224.209 36.2091 226 34 226C31.7909 226 30 224.209 30 222Z" fill="#059669"/>
+</g>
+<g opacity="0.550828">
+<path d="M46 222C46 219.791 47.7909 218 50 218H182C184.209 218 186 219.791 186 222C186 224.209 184.209 226 182 226H50C47.7909 226 46 224.209 46 222Z" fill="#E5E7EB"/>
+</g>
+<g opacity="0.681649">
+<path d="M30 242C30 239.791 31.7909 238 34 238C36.2091 238 38 239.791 38 242C38 244.209 36.2091 246 34 246C31.7909 246 30 244.209 30 242Z" fill="#059669"/>
+</g>
+<g opacity="0.681649">
+<path d="M46 242C46 239.791 47.7909 238 50 238H182C184.209 238 186 239.791 186 242C186 244.209 184.209 246 182 246H50C47.7909 246 46 244.209 46 242Z" fill="#E5E7EB"/>
+</g>
+</g>
+<g opacity="0.500293">
+<path d="M12 24C12 10.7452 22.7452 0 36 0H116C129.255 0 140 10.7452 140 24V104C140 117.255 129.255 128 116 128H36C22.7452 128 12 117.255 12 104V24Z" fill="url(#rmproc_paint_linear)"/>
+<path d="M82.6668 42.6666H69.3335L62.6668 50.6666H54.6668C53.2523 50.6666 51.8958 51.2285 50.8956 52.2287C49.8954 53.2289 49.3335 54.5855 49.3335 56V80C49.3335 81.4144 49.8954 82.771 50.8956 83.7712C51.8958 84.7714 53.2523 85.3333 54.6668 85.3333H97.3335C98.748 85.3333 100.105 84.7714 101.105 83.7712C102.105 82.771 102.667 81.4144 102.667 80V56C102.667 54.5855 102.105 53.2289 101.105 52.2287C100.105 51.2285 98.748 50.6666 97.3335 50.6666H89.3335L82.6668 42.6666Z" stroke="#059669" stroke-width="5.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M76 74.6666C80.4183 74.6666 84 71.0849 84 66.6666C84 62.2483 80.4183 58.6666 76 58.6666C71.5817 58.6666 68 62.2483 68 66.6666C68 71.0849 71.5817 74.6666 76 74.6666Z" stroke="#059669" stroke-width="5.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="rmproc_filter_dd" x="0" y="178" width="216" height="108" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect1_dropShadow_46_1675"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_46_1675"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="3" operator="erode" in="SourceAlpha" result="effect2_dropShadow_46_1675"/>
+<feOffset dy="10"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_46_1675" result="effect2_dropShadow_46_1675"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_46_1675" result="shape"/>
+</filter>
+<linearGradient id="rmproc_paint_linear" x1="12" y1="0" x2="140" y2="128" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ECFDF5"/>
+<stop offset="1" stop-color="#D1FAE5"/>
+</linearGradient>
+</defs>
+</svg>
+`.trim();
+
+type Props = {
+  width?: number;
+  height?: number;
+};
+
+export function RestaurantMenuProcessingIllustration({ width = 216, height = 286 }: Props) {
+  return <SvgXml xml={MENU_PROCESSING_ILLUSTRATION_XML} width={width} height={height} />;
+}

--- a/lib/pending-restaurant-menu-scan.ts
+++ b/lib/pending-restaurant-menu-scan.ts
@@ -1,0 +1,34 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@pickmyplate/pending_restaurant_menu_scan_v1';
+
+export type PendingRestaurantMenuScan = {
+  bucket: string;
+  path: string;
+  ts: number;
+};
+
+/** Persist last restaurant upload so processing screen can recover if route params are dropped. */
+export async function writePendingRestaurantMenuScan(bucket: string, path: string): Promise<void> {
+  const payload: PendingRestaurantMenuScan = { bucket, path, ts: Date.now() };
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export async function readPendingRestaurantMenuScan(): Promise<PendingRestaurantMenuScan | null> {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PendingRestaurantMenuScan;
+    if (typeof parsed.bucket === 'string' && typeof parsed.path === 'string') {
+      return parsed;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function clearPendingRestaurantMenuScan(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}
+

--- a/lib/restaurant-dish-image-api.ts
+++ b/lib/restaurant-dish-image-api.ts
@@ -1,0 +1,59 @@
+import Constants from 'expo-constants';
+
+import { supabase } from '@/lib/supabase';
+
+const MENU_API_KEY = 'EXPO_PUBLIC_MENU_API_URL';
+
+function getMenuApiBaseUrl(): string {
+  const fromEnv = process.env[MENU_API_KEY] ?? (Constants.expoConfig?.extra as { menuApiUrl?: string } | undefined)?.menuApiUrl;
+  const raw = typeof fromEnv === 'string' ? fromEnv.trim() : '';
+  return raw.replace(/\/$/, '');
+}
+
+export async function generateRestaurantDishImage(dishId: string): Promise<{ ok: true; imageUrl: string } | { ok: false; error: string }> {
+  const base = getMenuApiBaseUrl();
+  if (!base) {
+    return { ok: false, error: 'Missing EXPO_PUBLIC_MENU_API_URL (Flask base URL).' };
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (session?.access_token) {
+    headers.Authorization = `Bearer ${session.access_token}`;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${base}/v1/restaurant-dishes/${dishId}/generate-image`, {
+      method: 'POST',
+      headers,
+    });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Network error' };
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch {
+    return { ok: false, error: `Invalid JSON (${res.status})` };
+  }
+
+  if (res.ok && typeof json === 'object' && json !== null && 'ok' in json && (json as { ok: unknown }).ok === true) {
+    if ('image_url' in (json as any) && typeof (json as any).image_url === 'string') {
+      return { ok: true, imageUrl: (json as any).image_url };
+    }
+  }
+
+  if (typeof json === 'object' && json !== null && 'error' in json && typeof (json as any).error === 'string') {
+    return { ok: false, error: (json as any).error };
+  }
+
+  return { ok: false, error: `HTTP ${res.status}` };
+}
+

--- a/lib/restaurant-dish-photo-upload.ts
+++ b/lib/restaurant-dish-photo-upload.ts
@@ -1,0 +1,101 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+import * as ImagePicker from 'expo-image-picker';
+
+import { supabase } from '@/lib/supabase';
+
+export const RESTAURANT_DISH_IMAGES_BUCKET = 'dish-images';
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+async function uriToJpegForUpload(localUri: string): Promise<string> {
+  try {
+    const out = await ImageManipulator.manipulateAsync(localUri, [], {
+      compress: 0.92,
+      format: ImageManipulator.SaveFormat.JPEG,
+    });
+    return out.uri;
+  } catch {
+    return localUri;
+  }
+}
+
+/** Storage path: `{userId}/restaurant-dishes/{dishId}.jpg` — must match RLS first segment = auth uid. */
+export function restaurantDishImageStoragePath(userId: string, dishId: string): string {
+  return `${userId}/restaurant-dishes/${dishId}.jpg`;
+}
+
+/**
+ * Upload a picked/captured image to `dish-images` and persist `image_url` on `restaurant_menu_dishes`.
+ */
+export async function uploadRestaurantDishPhotoFromUri(params: {
+  localUri: string;
+  dishId: string;
+  userId: string;
+}): Promise<{ publicUrl: string }> {
+  const readUri = await uriToJpegForUpload(params.localUri);
+  const path = restaurantDishImageStoragePath(params.userId, params.dishId);
+
+  const res = await fetch(readUri);
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > MAX_BYTES) {
+    throw new Error('Image must be 5 MB or smaller.');
+  }
+
+  const { error: upErr } = await supabase.storage.from(RESTAURANT_DISH_IMAGES_BUCKET).upload(path, buf, {
+    contentType: 'image/jpeg',
+    upsert: true,
+  });
+  if (upErr) throw new Error(upErr.message);
+
+  const { data } = supabase.storage.from(RESTAURANT_DISH_IMAGES_BUCKET).getPublicUrl(path);
+  const publicUrl = data.publicUrl;
+
+  const { error: dbErr } = await supabase
+    .from('restaurant_menu_dishes')
+    .update({ image_url: publicUrl })
+    .eq('id', params.dishId);
+  if (dbErr) throw new Error(dbErr.message);
+
+  return { publicUrl };
+}
+
+export type PickUploadRestaurantDishPhotoResult =
+  | { ok: true; publicUrl: string }
+  | { ok: false; cancelled: true }
+  | { ok: false; error: string };
+
+/**
+ * Opens the photo library, uploads JPEG to `dish-images` under the current user, updates `restaurant_menu_dishes.image_url`.
+ */
+export async function pickAndUploadRestaurantDishPhoto(dishId: string): Promise<PickUploadRestaurantDishPhotoResult> {
+  const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (status !== 'granted') {
+    return { ok: false, error: 'Photo library access is needed to upload a dish photo.' };
+  }
+
+  const picker = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: 0.85,
+  });
+  if (picker.canceled || !picker.assets?.[0]?.uri) {
+    return { ok: false, cancelled: true };
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.id) {
+    return { ok: false, error: 'Not signed in.' };
+  }
+
+  try {
+    const { publicUrl } = await uploadRestaurantDishPhotoFromUri({
+      localUri: picker.assets[0].uri,
+      dishId,
+      userId: user.id,
+    });
+    return { ok: true, publicUrl };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Upload failed' };
+  }
+}

--- a/lib/restaurant-dish-summary-api.ts
+++ b/lib/restaurant-dish-summary-api.ts
@@ -1,0 +1,62 @@
+import Constants from 'expo-constants';
+
+import { supabase } from '@/lib/supabase';
+
+const MENU_API_KEY = 'EXPO_PUBLIC_MENU_API_URL';
+
+function getMenuApiBaseUrl(): string {
+  const fromEnv = process.env[MENU_API_KEY] ?? (Constants.expoConfig?.extra as { menuApiUrl?: string } | undefined)?.menuApiUrl;
+  const raw = typeof fromEnv === 'string' ? fromEnv.trim() : '';
+  return raw.replace(/\/$/, '');
+}
+
+export async function generateRestaurantDishSummary(
+  dishId: string,
+): Promise<{ ok: true; description: string | null } | { ok: false; error: string }> {
+  const base = getMenuApiBaseUrl();
+  if (!base) {
+    return { ok: false, error: 'Missing EXPO_PUBLIC_MENU_API_URL (Flask base URL).' };
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (session?.access_token) {
+    headers.Authorization = `Bearer ${session.access_token}`;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${base}/v1/restaurant-dishes/${dishId}/generate-summary`, {
+      method: 'POST',
+      headers,
+    });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Network error' };
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch {
+    return { ok: false, error: `Invalid JSON (${res.status})` };
+  }
+
+  if (res.ok && typeof json === 'object' && json !== null && 'ok' in json && (json as { ok: unknown }).ok === true) {
+    if ('description' in (json as any) && (json as any).description !== undefined) {
+      return { ok: true, description: (json as any).description as string | null };
+    }
+    return { ok: true, description: null };
+  }
+
+  if (typeof json === 'object' && json !== null && 'error' in json && typeof (json as any).error === 'string') {
+    return { ok: false, error: (json as any).error };
+  }
+
+  return { ok: false, error: `HTTP ${res.status}` };
+}
+

--- a/lib/restaurant-fetch-menu-for-scan.ts
+++ b/lib/restaurant-fetch-menu-for-scan.ts
@@ -1,0 +1,87 @@
+import { supabase } from '@/lib/supabase';
+
+export type RestaurantMenuSectionRow = {
+  id: string;
+  scan_id: string;
+  title: string;
+  sort_order: number;
+};
+
+export type RestaurantMenuDishRow = {
+  id: string;
+  section_id: string;
+  sort_order: number;
+  name: string;
+  description: string | null;
+  price_amount: number | null;
+  price_currency: string;
+  price_display: string | null;
+  spice_level: 0 | 1 | 2 | 3;
+  tags: string[];
+  ingredients: string[];
+  image_url: string | null;
+  needs_review: boolean;
+};
+
+export type FetchRestaurantMenuForScanResult =
+  | { ok: true; scan: { id: string; restaurant_name: string | null }; sections: RestaurantMenuSectionRow[]; dishes: RestaurantMenuDishRow[] }
+  | { ok: false; error: string };
+
+function coerceSpiceLevel(v: unknown): 0 | 1 | 2 | 3 {
+  if (v === 0 || v === 1 || v === 2 || v === 3) return v;
+  if (typeof v === 'number' && Number.isInteger(v)) {
+    const n = Math.max(0, Math.min(3, v));
+    return n as 0 | 1 | 2 | 3;
+  }
+  return 0;
+}
+
+export async function fetchRestaurantMenuForScan(scanId: string): Promise<FetchRestaurantMenuForScanResult> {
+  try {
+    const { data: scanRow, error: scanErr } = await supabase
+      .from('restaurant_menu_scans')
+      .select('id, restaurant_name')
+      .eq('id', scanId)
+      .maybeSingle();
+
+    if (scanErr) return { ok: false, error: scanErr.message };
+    if (!scanRow) return { ok: false, error: 'Scan not found' };
+
+    const { data: sections, error: secErr } = await supabase
+      .from('restaurant_menu_sections')
+      .select('id, scan_id, title, sort_order')
+      .eq('scan_id', scanId)
+      .order('sort_order', { ascending: true });
+
+    if (secErr) return { ok: false, error: secErr.message };
+
+    const sectionIds = (sections ?? []).map((s) => (s as RestaurantMenuSectionRow).id);
+    let dishes: RestaurantMenuDishRow[] = [];
+
+    if (sectionIds.length > 0) {
+      const { data: dishRows, error: dishErr } = await supabase
+        .from('restaurant_menu_dishes')
+        .select(
+          'id, section_id, sort_order, name, description, price_amount, price_currency, price_display, spice_level, tags, ingredients, image_url, needs_review',
+        )
+        .in('section_id', sectionIds)
+        .order('sort_order', { ascending: true });
+
+      if (dishErr) return { ok: false, error: dishErr.message };
+      dishes = (dishRows ?? []).map((d) => ({
+        ...(d as any),
+        spice_level: coerceSpiceLevel((d as any).spice_level),
+      })) as RestaurantMenuDishRow[];
+    }
+
+    return {
+      ok: true,
+      scan: { id: String(scanRow.id), restaurant_name: scanRow.restaurant_name ? String(scanRow.restaurant_name) : null },
+      sections: (sections ?? []) as RestaurantMenuSectionRow[],
+      dishes,
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Failed to load restaurant menu' };
+  }
+}
+

--- a/lib/restaurant-menu-dish-utils.ts
+++ b/lib/restaurant-menu-dish-utils.ts
@@ -1,0 +1,18 @@
+export type RestaurantMenuDishNeedsReviewInput = {
+  name: string | null | undefined;
+  priceAmount: number | null | undefined;
+  ingredients: unknown;
+};
+
+export function restaurantMenuDishNeedsReview(input: RestaurantMenuDishNeedsReviewInput): boolean {
+  const name = (input.name ?? '').trim();
+  const priceMissing = input.priceAmount === null || input.priceAmount === undefined;
+
+  const ingredients = input.ingredients;
+  const ingredientsArray = Array.isArray(ingredients) ? ingredients : [];
+
+  const ingredientsMissing = ingredientsArray.length === 0;
+
+  return name.length === 0 || priceMissing || ingredientsMissing;
+}
+

--- a/lib/restaurant-menu-dishes.ts
+++ b/lib/restaurant-menu-dishes.ts
@@ -1,0 +1,100 @@
+import { supabase } from '@/lib/supabase';
+import { restaurantMenuDishNeedsReview } from '@/lib/restaurant-menu-dish-utils';
+
+export type CreateRestaurantDishDraftInput = {
+  sectionId: string;
+  sortOrder: number;
+};
+
+export type CreateRestaurantDishDraftResult = { ok: true; dishId: string } | { ok: false; error: string };
+
+export async function getRestaurantSectionNextDishSortOrder(sectionId: string): Promise<number> {
+  const { data, error } = await supabase
+    .from('restaurant_menu_dishes')
+    .select('sort_order')
+    .eq('section_id', sectionId)
+    .order('sort_order', { ascending: false })
+    .limit(1);
+
+  if (error) throw error;
+  const top = (data ?? [])[0] as { sort_order: number } | undefined;
+  return typeof top?.sort_order === 'number' ? top.sort_order + 1 : 0;
+}
+
+export async function createRestaurantDishDraft(input: CreateRestaurantDishDraftInput): Promise<CreateRestaurantDishDraftResult> {
+  const { data, error } = await supabase
+    .from('restaurant_menu_dishes')
+    .insert({
+      section_id: input.sectionId,
+      sort_order: input.sortOrder,
+      name: '',
+      description: null,
+      price_amount: null,
+      price_currency: 'USD',
+      price_display: null,
+      spice_level: 0,
+      tags: [],
+      ingredients: [],
+      image_url: null,
+      needs_review: true,
+    })
+    .select('id')
+    .single();
+
+  if (error) return { ok: false, error: error.message };
+  if (!data?.id) return { ok: false, error: 'Failed to create dish draft' };
+  return { ok: true, dishId: String(data.id) };
+}
+
+export type SaveRestaurantDishInput = {
+  dishId: string;
+  scanId: string;
+  name: string;
+  description: string | null;
+  priceAmount: number | null;
+  priceCurrency: string;
+  priceDisplay: string | null;
+  spiceLevel: 0 | 1 | 2 | 3;
+  tags: string[];
+  ingredients: string[];
+  /**
+   * If true (default), updates the parent scan's last_activity_at so it moves
+   * to the top of "Recent uploads".
+   */
+  touchScan?: boolean;
+};
+
+export async function touchRestaurantMenuScan(scanId: string): Promise<void> {
+  // "last_activity_at" is what drives the "Recent uploads" list ordering.
+  const now = new Date().toISOString();
+  const { error } = await supabase.from('restaurant_menu_scans').update({ last_activity_at: now }).eq('id', scanId);
+  if (error) throw error;
+}
+
+export async function saveRestaurantDish(input: SaveRestaurantDishInput): Promise<{ ok: true } | { ok: false; error: string }> {
+  const needs_review = restaurantMenuDishNeedsReview({
+    name: input.name,
+    priceAmount: input.priceAmount,
+    ingredients: input.ingredients,
+  });
+
+  const { error } = await supabase.from('restaurant_menu_dishes').update({
+    name: input.name,
+    description: input.description,
+    price_amount: input.priceAmount,
+    price_currency: input.priceCurrency,
+    price_display: input.priceDisplay,
+    spice_level: input.spiceLevel,
+    tags: input.tags,
+    ingredients: input.ingredients,
+    needs_review,
+  }).eq('id', input.dishId);
+
+  if (error) return { ok: false, error: error.message };
+
+  if (input.touchScan ?? true) {
+    await touchRestaurantMenuScan(input.scanId);
+  }
+  return { ok: true };
+}
+

--- a/lib/restaurant-menu-parse-preferences.ts
+++ b/lib/restaurant-menu-parse-preferences.ts
@@ -1,0 +1,19 @@
+import { DIETARY_OPTIONS } from '@/lib/diner-preferences';
+
+/**
+ * For restaurant parsing we want the backend to allow tag generation
+ * for the same chip vocabulary the UI can render (dietary + spice).
+ *
+ * Backend enforces that generated tags are a subset of "allowed_tags".
+ */
+export function buildRestaurantMenuParseUserPreferences(): Record<string, unknown> {
+  return {
+    dietary: [...DIETARY_OPTIONS],
+    // Allow tagging only the "Spicy" label for now (matches the provided UI).
+    spice_label: 'Spicy',
+    budget_tier: null,
+    cuisines: [],
+    smart_tags: [],
+  };
+}
+

--- a/lib/restaurant-menu-scans.ts
+++ b/lib/restaurant-menu-scans.ts
@@ -1,0 +1,20 @@
+import { supabase } from '@/lib/supabase';
+
+export type RestaurantMenuScanListRow = {
+  id: string;
+  restaurant_name: string | null;
+  last_activity_at: string;
+};
+
+export async function fetchRestaurantRecentUploads(limit = 10): Promise<RestaurantMenuScanListRow[]> {
+  const { data, error } = await supabase
+    .from('restaurant_menu_scans')
+    .select('id, restaurant_name, last_activity_at')
+    .order('last_activity_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw error;
+
+  return (data ?? []) as RestaurantMenuScanListRow[];
+}
+

--- a/lib/restaurant-persist-menu.ts
+++ b/lib/restaurant-persist-menu.ts
@@ -1,0 +1,92 @@
+import type { ParsedMenu, ParsedMenuSection, ParsedMenuItem } from '@/lib/menu-scan-schema';
+import { supabase } from '@/lib/supabase';
+import { restaurantMenuDishNeedsReview } from '@/lib/restaurant-menu-dish-utils';
+
+export type PersistRestaurantMenuDraftResult =
+  | { ok: true; scanId: string }
+  | { ok: false; error: string };
+
+function coerceSpiceLevel(v: unknown): 0 | 1 | 2 | 3 {
+  if (v === 0 || v === 1 || v === 2 || v === 3) return v;
+  if (typeof v === 'number' && Number.isInteger(v)) {
+    const n = Math.max(0, Math.min(3, v));
+    return n as 0 | 1 | 2 | 3;
+  }
+  return 0;
+}
+
+export async function persistRestaurantMenuDraft(menu: ParsedMenu, restaurantId: string): Promise<PersistRestaurantMenuDraftResult> {
+  const restaurantName = menu.restaurant_name?.trim() || null;
+
+  const { data: scanRow, error: scanErr } = await supabase
+    .from('restaurant_menu_scans')
+    .insert({
+      restaurant_id: restaurantId,
+      restaurant_name: restaurantName,
+    })
+    .select('id')
+    .single();
+
+  if (scanErr || !scanRow?.id) {
+    return { ok: false, error: scanErr?.message ?? 'Failed to create menu scan' };
+  }
+
+  const scanId = scanRow.id as string;
+
+  const sectionRows: Array<{
+    id: string;
+    scan_id: string;
+    title: string;
+    sort_order: number;
+  }> = menu.sections.map((s: ParsedMenuSection, i: number) => ({
+    id: s.id,
+    scan_id: scanId,
+    title: s.title,
+    sort_order: i,
+  }));
+
+  if (sectionRows.length > 0) {
+    const { error: secErr } = await supabase.from('restaurant_menu_sections').insert(sectionRows);
+    if (secErr) {
+      await supabase.from('restaurant_menu_scans').delete().eq('id', scanId);
+      return { ok: false, error: secErr.message };
+    }
+  }
+
+  const dishRows: Array<Record<string, unknown>> = [];
+  for (const sec of menu.sections) {
+    sec.items.forEach((it: ParsedMenuItem, j: number) => {
+      const needs_review = restaurantMenuDishNeedsReview({
+        name: it.name,
+        priceAmount: it.price.amount,
+        ingredients: it.ingredients,
+      });
+      dishRows.push({
+        id: it.id,
+        section_id: sec.id,
+        sort_order: j,
+        name: it.name,
+        description: it.description,
+        price_amount: it.price.amount,
+        price_currency: it.price.currency,
+        price_display: it.price.display,
+        spice_level: coerceSpiceLevel(it.spice_level),
+        tags: it.tags,
+        ingredients: it.ingredients,
+        image_url: null,
+        needs_review,
+      });
+    });
+  }
+
+  if (dishRows.length > 0) {
+    const { error: dishErr } = await supabase.from('restaurant_menu_dishes').insert(dishRows);
+    if (dishErr) {
+      await supabase.from('restaurant_menu_scans').delete().eq('id', scanId);
+      return { ok: false, error: dishErr.message };
+    }
+  }
+
+  return { ok: true, scanId };
+}
+

--- a/lib/restaurant-publish-menu.ts
+++ b/lib/restaurant-publish-menu.ts
@@ -1,0 +1,10 @@
+import { supabase } from '@/lib/supabase';
+
+export type PublishRestaurantMenuResult = { ok: true } | { ok: false; error: string };
+
+export async function publishRestaurantMenu(scanId: string): Promise<PublishRestaurantMenuResult> {
+  const { data, error } = await supabase.rpc('publish_restaurant_menu', { target_scan_id: scanId });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}
+

--- a/lib/restaurant-rename-menu-scan.ts
+++ b/lib/restaurant-rename-menu-scan.ts
@@ -1,0 +1,23 @@
+import { supabase } from '@/lib/supabase';
+
+const MAX_LEN = 120;
+
+export type RenameMenuScanResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Updates the display name for a menu scan (header title on review / diner-facing label source).
+ */
+export async function updateRestaurantMenuScanName(scanId: string, rawName: string): Promise<RenameMenuScanResult> {
+  const restaurant_name = rawName.trim();
+  if (!restaurant_name) {
+    return { ok: false, error: 'Please enter a menu name.' };
+  }
+  if (restaurant_name.length > MAX_LEN) {
+    return { ok: false, error: `Menu name must be ${MAX_LEN} characters or fewer.` };
+  }
+
+  const { error } = await supabase.from('restaurant_menu_scans').update({ restaurant_name }).eq('id', scanId);
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}

--- a/lib/restaurant-setup.ts
+++ b/lib/restaurant-setup.ts
@@ -106,3 +106,19 @@ export async function ensureDinerRole(): Promise<{ error: Error | null }> {
   if (error) return { error };
   return { error: null };
 }
+
+/**
+ * Get the restaurant id for the currently signed-in restaurant owner.
+ * Returns null if the owner hasn't completed restaurant onboarding yet.
+ */
+export async function fetchRestaurantIdForOwner(): Promise<{ restaurantId: string | null; error: Error | null }> {
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  const user = userData?.user;
+  if (userError || !user) {
+    return { restaurantId: null, error: userError ?? new Error('Not signed in') };
+  }
+
+  const { data: row, error: rErr } = await supabase.from('restaurants').select('id').eq('owner_id', user.id).maybeSingle();
+  if (rErr) return { restaurantId: null, error: rErr };
+  return { restaurantId: row?.id ? String(row.id) : null, error: null };
+}

--- a/lib/user-roles.ts
+++ b/lib/user-roles.ts
@@ -3,12 +3,36 @@ import { filterAppRoles } from '@/lib/app-role';
 import { getErrorMessage } from '@/lib/error-message';
 import { supabase } from '@/lib/supabase';
 
-export async function fetchUserRoles(userId: string): Promise<AppRole[]> {
-  const { data, error } = await supabase
-    .from('user_roles')
-    .select('role')
-    .eq('user_id', userId);
+const DEFAULT_TIMEOUT_MS = 10000;
 
-  if (error) throw new Error(getErrorMessage(error));
-  return filterAppRoles((data ?? []).map((r) => r.role));
+function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  let t: ReturnType<typeof setTimeout> | null = null;
+  return Promise.race([
+    fn().finally(() => {
+      if (t) clearTimeout(t);
+    }),
+    new Promise<T>((_, reject) => {
+      t = setTimeout(() => {
+        reject(new Error(`${label} timed out after ${ms}ms`));
+      }, ms);
+    }),
+  ]);
+}
+
+export async function fetchUserRoles(userId: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<AppRole[]> {
+  const res = await withTimeout(
+    async () => {
+      return await supabase.from('user_roles').select('role').eq('user_id', userId);
+    },
+    timeoutMs,
+    'fetchUserRoles',
+  );
+
+  const { data, error } = res as { data: Array<{ role: unknown }> | null; error: unknown };
+
+  if (error) throw new Error(getErrorMessage(error as any));
+
+  return filterAppRoles(
+    (data ?? []).map((r) => r.role).filter((x): x is AppRole => typeof x === 'string') as AppRole[],
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1",
         "react-native-url-polyfill": "^3.0.0",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1"
@@ -91,7 +92,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1473,7 +1473,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3059,7 +3058,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.0.tgz",
       "integrity": "sha512-kEuqIS1MkzzLD45Fp17CrxAchoB4W6tMfc541merUgtAeNNsg06gRrvmuLv6LAYvpLifGdXuSjpluPIu/VmbQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.0",
         "escape-string-regexp": "^4.0.0",
@@ -3365,7 +3363,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3445,7 +3442,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4033,7 +4029,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4713,6 +4708,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -4775,7 +4776,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5247,6 +5247,56 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5473,6 +5523,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -5540,6 +5645,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -5771,7 +5888,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5968,7 +6084,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6207,7 +6322,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -6275,7 +6389,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -6303,7 +6416,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6398,7 +6510,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -9112,6 +9223,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -9742,6 +9859,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -10508,7 +10637,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10528,7 +10656,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10565,7 +10692,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -10623,7 +10749,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -10649,7 +10774,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -10677,7 +10801,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10688,11 +10811,25 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -10716,7 +10853,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -10749,7 +10885,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10860,7 +10995,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12230,7 +12364,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12437,7 +12570,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1",
     "react-native-url-polyfill": "^3.0.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1"

--- a/supabase/migrations/20260326160000_restaurant_menu_uploads_and_published.sql
+++ b/supabase/migrations/20260326160000_restaurant_menu_uploads_and_published.sql
@@ -1,0 +1,441 @@
+-- Restaurant menu upload, review, and publish (Sprint 1; images-only MVP)
+-- This introduces a restaurant-scoped "menu draft" (scan + sections + dishes)
+-- and publishes exactly one scan per restaurant to be readable by diners.
+
+-- ---------------------------------------------------------------------------
+-- restaurant_menu_scans
+-- ---------------------------------------------------------------------------
+create table public.restaurant_menu_scans (
+  id uuid primary key default gen_random_uuid(),
+  restaurant_id uuid not null references public.restaurants (id) on delete cascade,
+  restaurant_name text,
+  scanned_at timestamptz not null default now(),
+  last_activity_at timestamptz not null default now(),
+  published_at timestamptz,
+  is_published boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.restaurant_menu_scans is
+  'Restaurant menu drafts/scans. Owners review/edit dishes; publish marks one scan as live. Customers/diners should read only the published scan.';
+
+comment on column public.restaurant_menu_scans.restaurant_name is
+  'Denormalized title for the scan (e.g. inferred from menu header/logo).';
+
+create index restaurant_menu_scans_restaurant_last_activity_idx
+  on public.restaurant_menu_scans (restaurant_id, last_activity_at desc);
+
+create index restaurant_menu_scans_restaurant_published_idx
+  on public.restaurant_menu_scans (restaurant_id, is_published, published_at desc);
+
+create trigger restaurant_menu_scans_set_updated_at
+  before update on public.restaurant_menu_scans
+  for each row
+  execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- restaurant_menu_sections
+-- ---------------------------------------------------------------------------
+create table public.restaurant_menu_sections (
+  id uuid primary key default gen_random_uuid(),
+  scan_id uuid not null references public.restaurant_menu_scans (id) on delete cascade,
+  title text not null,
+  sort_order int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.restaurant_menu_sections is
+  'Section headings for a scanned restaurant menu draft.';
+
+create index restaurant_menu_sections_scan_sort_idx
+  on public.restaurant_menu_sections (scan_id, sort_order);
+
+create trigger restaurant_menu_sections_set_updated_at
+  before update on public.restaurant_menu_sections
+  for each row
+  execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- restaurant_menu_dishes
+-- ---------------------------------------------------------------------------
+create table public.restaurant_menu_dishes (
+  id uuid primary key default gen_random_uuid(),
+  section_id uuid not null references public.restaurant_menu_sections (id) on delete cascade,
+  sort_order int not null default 0,
+  name text not null default '',
+  description text,
+  price_amount numeric(12, 2),
+  price_currency text not null default 'USD',
+  price_display text,
+  spice_level int not null
+    constraint restaurant_menu_dishes_spice_level_check
+    check (spice_level >= 0 and spice_level <= 3),
+  tags text[] not null default '{}',
+  ingredients text[] not null default '{}',
+  image_url text,
+  needs_review boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.restaurant_menu_dishes is
+  'One row per dish for a restaurant menu draft. needs_review drives the review UI.';
+
+create index restaurant_menu_dishes_section_sort_idx
+  on public.restaurant_menu_dishes (section_id, sort_order);
+
+create trigger restaurant_menu_dishes_set_updated_at
+  before update on public.restaurant_menu_dishes
+  for each row
+  execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- restaurants: active published scan pointer
+-- ---------------------------------------------------------------------------
+alter table public.restaurants
+  add column if not exists published_menu_scan_id uuid;
+
+comment on column public.restaurants.published_menu_scan_id is
+  'Which restaurant_menu_scans row is currently live/published for customers.';
+
+alter table public.restaurants
+  add constraint restaurants_published_menu_scan_fk
+  foreign key (published_menu_scan_id)
+  references public.restaurant_menu_scans (id)
+  on delete set null;
+
+-- ---------------------------------------------------------------------------
+-- RLS helpers: ownership checks are written inline for clarity
+-- ---------------------------------------------------------------------------
+alter table public.restaurant_menu_scans enable row level security;
+alter table public.restaurant_menu_sections enable row level security;
+alter table public.restaurant_menu_dishes enable row level security;
+
+-- ============ restaurant_menu_scans policies ============
+
+create policy "restaurant_menu_scans_owner_select"
+  on public.restaurant_menu_scans
+  for select
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_scans_owner_insert"
+  on public.restaurant_menu_scans
+  for insert
+  to authenticated
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_scans_owner_update"
+  on public.restaurant_menu_scans
+  for update
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.owner_id = (select auth.uid())
+    )
+  )
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_scans_owner_delete"
+  on public.restaurant_menu_scans
+  for delete
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_scans_diner_select_published_only"
+  on public.restaurant_menu_scans
+  for select
+  to authenticated
+  using (
+    public.is_diner((select auth.uid()))
+    and is_published = true
+    and exists (
+      select 1
+      from public.restaurants r
+      where r.id = restaurant_id
+        and r.published_menu_scan_id = id
+    )
+  );
+
+-- ============ restaurant_menu_sections policies ============
+
+create policy "restaurant_menu_sections_owner_select"
+  on public.restaurant_menu_sections
+  for select
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_sections_owner_insert"
+  on public.restaurant_menu_sections
+  for insert
+  to authenticated
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_sections_owner_update"
+  on public.restaurant_menu_sections
+  for update
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.owner_id = (select auth.uid())
+    )
+  )
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_sections_owner_delete"
+  on public.restaurant_menu_sections
+  for delete
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_sections_diner_select_published_only"
+  on public.restaurant_menu_sections
+  for select
+  to authenticated
+  using (
+    public.is_diner((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_scans s
+      join public.restaurants r on r.id = s.restaurant_id
+      where s.id = scan_id
+        and r.published_menu_scan_id = s.id
+        and s.is_published = true
+    )
+  );
+
+-- ============ restaurant_menu_dishes policies ============
+
+create policy "restaurant_menu_dishes_owner_select"
+  on public.restaurant_menu_dishes
+  for select
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_dishes_owner_insert"
+  on public.restaurant_menu_dishes
+  for insert
+  to authenticated
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_dishes_owner_update"
+  on public.restaurant_menu_dishes
+  for update
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.owner_id = (select auth.uid())
+    )
+  )
+  with check (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_dishes_owner_delete"
+  on public.restaurant_menu_dishes
+  for delete
+  to authenticated
+  using (
+    public.is_restaurant((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.owner_id = (select auth.uid())
+    )
+  );
+
+create policy "restaurant_menu_dishes_diner_select_published_only"
+  on public.restaurant_menu_dishes
+  for select
+  to authenticated
+  using (
+    public.is_diner((select auth.uid()))
+    and exists (
+      select 1
+      from public.restaurant_menu_sections sec
+      join public.restaurant_menu_scans s on s.id = sec.scan_id
+      join public.restaurants r on r.id = s.restaurant_id
+      where sec.id = section_id
+        and r.published_menu_scan_id = s.id
+        and s.is_published = true
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Publish RPC: blocks publish if any dish still needs review
+-- ---------------------------------------------------------------------------
+create or replace function public.publish_restaurant_menu(target_scan_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rest_id uuid;
+  owner_id uuid;
+  needs_review_count int;
+begin
+  -- Find the restaurant owning the scan
+  select restaurant_id into rest_id
+  from public.restaurant_menu_scans
+  where id = target_scan_id;
+
+  if rest_id is null then
+    raise exception 'restaurant menu scan not found';
+  end if;
+
+  select r.owner_id into owner_id
+  from public.restaurants r
+  where r.id = rest_id;
+
+  if owner_id is null or owner_id <> auth.uid() then
+    raise exception 'unauthorized';
+  end if;
+
+  -- Enforce review completion
+  select count(*) into needs_review_count
+  from public.restaurant_menu_dishes d
+  join public.restaurant_menu_sections sec on sec.id = d.section_id
+  where sec.scan_id = target_scan_id
+    and d.needs_review = true;
+
+  if needs_review_count > 0 then
+    raise exception 'menu has items needing review (count=%)', needs_review_count;
+  end if;
+
+  -- Mark this scan published, and unpublish siblings
+  update public.restaurant_menu_scans
+  set is_published = false,
+      published_at = null
+  where restaurant_id = rest_id;
+
+  update public.restaurant_menu_scans
+  set is_published = true,
+      published_at = now(),
+      last_activity_at = now()
+  where id = target_scan_id;
+
+  update public.restaurants
+  set published_menu_scan_id = target_scan_id
+  where id = rest_id;
+
+  return;
+end;
+$$;
+

--- a/supabase/migrations/20260330120000_storage_dish_images_owner_policies.sql
+++ b/supabase/migrations/20260330120000_storage_dish_images_owner_policies.sql
@@ -1,0 +1,42 @@
+-- Allow authenticated users to upload their own dish photos to the public `dish-images` bucket.
+-- Path convention: {auth.uid()}/restaurant-dishes/{dish_id}.jpg
+
+create policy "dish_images_select_own"
+  on storage.objects
+  for select
+  to authenticated
+  using (
+    bucket_id = 'dish-images'
+    and split_part(name, '/', 1) = (select auth.uid())::text
+  );
+
+create policy "dish_images_insert_own"
+  on storage.objects
+  for insert
+  to authenticated
+  with check (
+    bucket_id = 'dish-images'
+    and split_part(name, '/', 1) = (select auth.uid())::text
+  );
+
+create policy "dish_images_update_own"
+  on storage.objects
+  for update
+  to authenticated
+  using (
+    bucket_id = 'dish-images'
+    and split_part(name, '/', 1) = (select auth.uid())::text
+  )
+  with check (
+    bucket_id = 'dish-images'
+    and split_part(name, '/', 1) = (select auth.uid())::text
+  );
+
+create policy "dish_images_delete_own"
+  on storage.objects
+  for delete
+  to authenticated
+  using (
+    bucket_id = 'dish-images'
+    and split_part(name, '/', 1) = (select auth.uid())::text
+  );

--- a/supabase/migrations/20260330120100_publish_restaurant_menu_allow_unreviewed.sql
+++ b/supabase/migrations/20260330120100_publish_restaurant_menu_allow_unreviewed.sql
@@ -1,0 +1,47 @@
+-- Allow publishing even when some dishes still have needs_review = true.
+-- Owners are warned in the app UI before confirming.
+
+create or replace function public.publish_restaurant_menu(target_scan_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rest_id uuid;
+  owner_id uuid;
+begin
+  select restaurant_id into rest_id
+  from public.restaurant_menu_scans
+  where id = target_scan_id;
+
+  if rest_id is null then
+    raise exception 'restaurant menu scan not found';
+  end if;
+
+  select r.owner_id into owner_id
+  from public.restaurants r
+  where r.id = rest_id;
+
+  if owner_id is null or owner_id <> auth.uid() then
+    raise exception 'unauthorized';
+  end if;
+
+  update public.restaurant_menu_scans
+  set is_published = false,
+      published_at = null
+  where restaurant_id = rest_id;
+
+  update public.restaurant_menu_scans
+  set is_published = true,
+      published_at = now(),
+      last_activity_at = now()
+  where id = target_scan_id;
+
+  update public.restaurants
+  set published_menu_scan_id = target_scan_id
+  where id = rest_id;
+
+  return;
+end;
+$$;

--- a/supabase/migrations/20260401120000_publish_restaurant_menu_allow_unreviewed_repeat.sql
+++ b/supabase/migrations/20260401120000_publish_restaurant_menu_allow_unreviewed_repeat.sql
@@ -1,0 +1,47 @@
+-- Idempotent repeat: some hosted projects never applied 20260330120100.
+-- Publish must NOT block on needs_review (UI warns; owner can confirm).
+
+create or replace function public.publish_restaurant_menu(target_scan_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rest_id uuid;
+  owner_id uuid;
+begin
+  select restaurant_id into rest_id
+  from public.restaurant_menu_scans
+  where id = target_scan_id;
+
+  if rest_id is null then
+    raise exception 'restaurant menu scan not found';
+  end if;
+
+  select r.owner_id into owner_id
+  from public.restaurants r
+  where r.id = rest_id;
+
+  if owner_id is null or owner_id <> auth.uid() then
+    raise exception 'unauthorized';
+  end if;
+
+  update public.restaurant_menu_scans
+  set is_published = false,
+      published_at = null
+  where restaurant_id = rest_id;
+
+  update public.restaurant_menu_scans
+  set is_published = true,
+      published_at = now(),
+      last_activity_at = now()
+  where id = target_scan_id;
+
+  update public.restaurants
+  set published_menu_scan_id = target_scan_id
+  where id = rest_id;
+
+  return;
+end;
+$$;


### PR DESCRIPTION
# Pull Request: Restaurant menu upload, scan, review, and publish

## Summary

This work adds the **restaurant-owner** flow to **upload a menu image**, run **AI parsing** (Flask + Vertex/Gemini), **review and edit dishes** (including add/remove items), optionally **upload dish photos** to Supabase Storage, use **AI-generated images and summaries** where configured, **rename the menu** from the review screen, and **publish** a draft scan as the live menu for diners. The restaurant shell uses a **green** accent theme (`constants/role-theme.ts` — `restaurantRoleTheme`).

---

## User-facing features

| Area | Behavior |
|------|----------|
| **Home** | Recent menu uploads; entry points to camera/library scan. |
| **Processing** | “Processing your menu…” with green-themed SVG illustration (`components/RestaurantMenuProcessingIllustration.tsx`, `react-native-svg`). |
| **Review menu** | List of dishes with cards, needs-review styling, progress + **Publish Menu** (gradient CTA). **Rename menu** via pencil next to the title; updates `restaurant_menu_scans.restaurant_name`. |
| **Publish** | If some dishes still need review, the app **warns** and offers **Publish anyway**; publishing must **not** be blocked server-side once migrations are applied (see below). |
| **Add / edit dish** | Layout aligned to design spec: photo area, **Upload Photo** + **Generate by AI** (image), fields for name, price, summary with **Generate by AI** (summary), spice level, ingredients (comma-separated), optional tags; **Save** returns to review. |
| **Dish photos** | Client uploads to Storage bucket **`dish-images`** with owner-scoped paths; `restaurant_menu_dishes.image_url` updated (`lib/restaurant-dish-photo-upload.ts`). |

---

## Backend (Flask)

HTTP routes are defined in `backend/app.py`:

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/health` | Liveness. |
| `POST` | `/v1/parse-menu` | Parse uploaded menu image → structured menu JSON → persisted by app after validation. |
| `POST` | `/v1/dishes/<dish_id>/generate-image` | Diner / legacy dish image generation. |
| `POST` | `/v1/restaurant-dishes/<dish_id>/generate-image` | Restaurant dish image generation. |
| `POST` | `/v1/restaurant-dishes/<dish_id>/generate-summary` | Restaurant dish summary/description (Vertex/Gemini). |

**Requirements for AI features:** GCP/Vertex config in the backend environment (e.g. `GCP_PROJECT`, `VERTEX_LOCATION`, `GEMINI_MODEL`), Supabase **service role** for server-side table/storage access where used, and a reachable **`EXPO_PUBLIC_MENU_API_URL`** from the mobile app (see precautions).

---

## Supabase (migrations to know)

Apply migrations to **local** and **hosted** projects before relying on the feature set:

| Migration (examples) | Notes |
|----------------------|--------|
| `20260326160000_restaurant_menu_uploads_and_published.sql` | Core tables: `restaurant_menu_scans`, sections, dishes, publish RPC (older version may **block** publish when `needs_review` is true). |
| `20260330120000_storage_dish_images_owner_policies.sql` | Storage RLS for `dish-images` uploads under user-owned paths. |
| `20260330120100_publish_restaurant_menu_allow_unreviewed.sql` | Replaces `publish_restaurant_menu` so publish **does not** fail when dishes still need review. |
| `20260401120000_publish_restaurant_menu_allow_unreviewed_repeat.sql` | Idempotent repeat of the above for projects that missed the earlier file. |

If publish still returns `menu has items needing review (count=…)`, the hosted DB has **not** applied the replacement function—run `supabase db push` or execute the SQL from those migrations in the dashboard.

---

## App modules (reference)

- **Fetch / persist:** `lib/restaurant-fetch-menu-for-scan.ts`, `lib/restaurant-persist-menu.ts`, `lib/restaurant-menu-dishes.ts`, `lib/restaurant-publish-menu.ts`, `lib/restaurant-rename-menu-scan.ts`
- **API clients:** `lib/restaurant-dish-image-api.ts`, `lib/restaurant-dish-summary-api.ts`, `lib/menu-parse-api.ts`
- **Screens:** `app/restaurant-home.tsx`, `app/restaurant-menu-processing.tsx`, `app/restaurant-review-menu.tsx`, `app/restaurant-add-dish.tsx`, `app/restaurant-edit-dish/[dishId].tsx`, `app/restaurant-menu.tsx`

---

## Precautions (before merge / deploy)

### Environment

1. **Mobile (`.env`):** `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_KEY` (anon), **`EXPO_PUBLIC_MENU_API_URL`** — Flask base URL **without** trailing slash. On a **physical device**, use the dev machine’s **LAN IP**, not `localhost`. Restart Metro after changes.
2. **Backend:** Do not commit secrets—`.env`, service keys, or GCP credential JSON. Document required vars in `backend/.env.example` / `README` as appropriate.
3. **AI:** Summary/image generation requires backend Vertex setup; failures should surface in the UI (alerts) when save or API calls fail—verify with a real device and reachable API.

### Database

4. **Order:** Apply migrations in order; **publish** behavior depends on the **`publish_restaurant_menu`** definition without the needs-review guard.
5. **Hosted Supabase:** Link project and `supabase db push`, or run equivalent SQL in the SQL editor for production.

### Storage

6. Buckets **`menu-uploads`** (scan images) and **`dish-images`** (dish photos) must exist and match policy migrations; public URL vs signed access must match how the app loads images.

### Product / QA

7. **Mock parse:** If `MOCK_MENU_PARSE` is enabled on the backend, parsing may return demo data—disable for real menu tests.
8. **Publish anyway:** UX warns first; server must allow publish after migrations—retest end-to-end on hosted DB.
9. **Rename menu:** Requires authenticated owner update on `restaurant_menu_scans` (RLS).

---

## Suggested PR checklist

- [ ] `npm install` (includes `react-native-svg` if using the processing illustration).
- [ ] `.env` set; device can reach Flask API.
- [ ] Supabase migrations applied on target; publish RPC verified (no “needs review” exception when publishing anyway).
- [ ] Smoke: upload → processing → review → edit dish → optional photo upload → summary/image AI (if configured) → rename menu → publish.
- [ ] No secrets committed.

---

## Related docs

- `README.md` — env and local run.
- `MENU_SCAN_FEATURE.md` — broader menu-scan pipeline notes (parser, strategies); some sections are diner-focused; cross-check with this file for **restaurant** flows.
