### PR TITLE
docs: Add human acceptance test for US3 AI generated dish image

### DIFF
--- a/docs/human_tests/us3-ai-generated-dish-image.md
+++ b/docs/human_tests/us3-ai-generated-dish-image.md
@@ -126,25 +126,29 @@ Use the template below for each classmate trial.
 
 ```md
 ### Tester
-- Name:
-- Team:
-- Date:
-- Device:
+- Name: Scarlett
+- Team: Gradient
+- Date: 4/7
+- Device: Mac + iPhone 16 pro max
 
 ### Observations
-- Could open dish page without help: Yes / No
-- Could find and use `View AI Image`: Yes / No
-- Image appeared on dish detail page: Yes / No
+- Could open dish page without help: Yes
+- Could find and use `View AI Image`: Yes
+- Image appeared on dish detail page: Yes 
 - First-run generation time:
-- Second-run or reopen appeared cached: Yes / No / Not tested
-- Tester understood image was approximate: Yes / No
+- Second-run or reopen appeared cached: Yes
+- Tester understood image was approximate: Yes
 
 ### Survey Responses
-1.
-2.
-3.
+1. Before you saw the generated image, how clearly could you picture the dish, and what became clearer after the image appeared?
+- before i saw the image, i might not be able to fully imagine the dish but with the image, the feature of the picture (like the sesame, or the pudding shape) helps me visualize it better. (my dish was sesame pudding)
+2. If this dish arrived looking somewhat different from the image, would that feel acceptable or misleading to you? Why?
+- it might, as i was expecting the real dish match the AI generated
+3. In a real ordering situation, would having this image make you more likely, less likely, or no more likely to consider ordering the dish? Explain what drove that reaction.
+- i think more likely, as the picture always gonna look better and help me better visualize what would i get for my dish
+
 
 ### Outcome
-- Passed / Failed
-- Follow-up changes needed:
+- Passed
+- Follow-up changes needed: N/A
 ```


### PR DESCRIPTION
## Summary

This PR adds the human-verifiable acceptance test documentation for User Story 3: AI Generated Dish Image.

User Story 3:
As a restaurant diner, I want to see a visual preview of a dish even if the restaurant does not have professional photos so that I can better imagine what the food will look like before ordering.

## What Changed

Added:
- [docs/human_tests/us3-ai-generated-dish-image.md](/Users/sofiayu/Desktop/2025-2026/17356/PickMyPlate2/docs/human_tests/us3-ai-generated-dish-image.md)

This document includes:
- test preconditions and setup instructions
- step-by-step instructions for a human tester
- expected outcomes tied to the implemented feature
- three user satisfaction metrics with justification
- three survey questions focused on decision value and trust
- pass thresholds for human acceptance
- a reusable participant test log template

## Why

This story is intended to help diners visualize dishes even when restaurants do not have professional photos. The acceptance test is designed to verify that the implemented feature helps users:
- generate and view an AI image from the dish detail page
- use the image to better visualize the dish
- understand that the image is an approximation, not an exact photo
- judge whether the image adds value to a real ordering decision

## Testing

Documentation only.
No app code was changed.

## User Story Covered

- US3: AI Generated Dish Image
