### PR TITLE
docs: Human acceptance test for US1 — Menu Scanning (Customer)

### DIFF
--- a/docs/human-tests/us1-menu-scanning.md
+++ b/docs/human-tests/us1-menu-scanning.md
@@ -268,6 +268,9 @@ Place the menu flat on a table under normal indoor lighting before handing the d
 **Q1 response (refined from tester's own words):**
 Score: 3.5 / 5. The scanning feature and the resulting digital menu look polished and useful, but the menu processing time feels noticeably long. During that wait he would likely fall back to the physical menu rather than holding the phone and watching the screen — which defeats the purpose of the feature in a real restaurant setting.
 
+**Note on Q1 — processing time constraint:**
+The long processing time flagged in Q1 is currently a hard constraint of the underlying large language model pipeline. LLM inference latency is not trivially reducible at the application level; meaningful improvements would require either a faster model, streaming token output piped to the UI, or background processing with a push notification when the menu is ready. The recommended near-term mitigation therefore remains a UX fix — replacing the simulated progress bar with an honest wait-time message — rather than a performance optimization, which is out of scope for the current sprint.
+
 **Q2 response (refined from tester's own words):**
 The frontend animations throughout the app feel polished and natural — the scan workflow, page transitions, and every individual screen all behave smoothly. The one exception is the progress bar on the processing screen: it appears to be a simulated animation rather than a real reflection of backend progress. This created a moment of genuine doubt about whether the menu was actually being processed or whether something had stalled silently.
 


### PR DESCRIPTION
## Summary

This PR adds the human-verifiable acceptance test documentation for **[User Story 1 — Menu Scanning (Customer)](https://github.com/qianxuege/PickMyPlate2/issues/9)** and includes the completed session log from a classmate tester.

Closes #42

---

## What Changed

Added: `docs/human-tests/us1-menu-scanning.md`

### Document contents

- **Story scope** — sub-flows covered: scan entry point, camera/library capture, processing screen, digital menu output, dish detail navigation, error handling
- **System setup prerequisites** — exact shell commands for Flask backend, `.env` configuration, Expo start, test account setup, and physical menu prop requirements
- **5 facilitator-guided test tasks** with expected outcomes per task:
  - Task 1: open the scan interface from the Home screen
  - Task 2: capture and submit the menu; observe the processing screen
  - Task 3: review the digital menu for accuracy
  - Task 4: navigate to a dish detail page and back
  - Task 5 (optional): edge case with an unusable image
- **3 salient satisfaction metrics** with justification grounded in *The Lean Startup* and *The Mom Test*:
  1. Unaided task-completion rate (Activation — did they reach the digital menu without coaching?)
  2. Perceived accuracy trust (revealed preference — would they actually order from the app's output?)
  3. Time-to-first-scroll (behavioral engagement, not stated preference)
- **3 survey questions** designed to surface genuine feedback rather than polite approval:
  - Q1: reliance Likert (behavioral intent proxy, not "was it accurate?")
  - Q2: open retrospective narration (surfaces unexpected friction per Mom Test)
  - Q3: "what would you miss?" framing (forces articulation of real value or exposes its absence)
- **Pass thresholds** table
- **Tester log** — completed with Session 1 results

---

## Classmate Test Session

**Tester:** Eric Du (different team, 17-766)
**Date:** 2026-04-07

### Key findings

| Criterion | Result |
|---|---|
| Scan entry found unaided | Yes |
| Navigated back without help | Yes |
| Q1 reliance score | 3.5 / 5 |
| Overall verdict | **Conditional Pass** |

### Survey responses (summarized)

**Q1 (3.5/5):** The scanning feature and digital menu output look polished, but the processing time is noticeably long. In a real restaurant setting Eric would likely fall back to the physical menu during the wait rather than holding the phone and watching a loading screen.

**Q2:** All frontend animations throughout the app feel natural and polished — scan workflow, page transitions, and individual screens all behave smoothly. The exception is the progress bar on the processing screen, which is a simulated animation rather than a real reflection of backend progress. This created genuine doubt about whether the menu was being processed or had silently stalled.

**Q3:** He would miss the AI-generated dish image feature most. When visiting an unfamiliar restaurant, being able to see a visual preview of a dish — even AI-generated — is meaningfully helpful for making an ordering decision. He considers it one of the more valuable parts of the overall app experience.

---

## Pass / Fail Verdict

**Conditional Pass.** The core scan-to-digital-menu flow is self-serve and feels polished. The Q1 score of 3.5 falls below the ≥ 4 threshold due to one specific issue: the processing time UX.

### Follow-up action identified

The simulated progress bar on the processing screen creates uncertainty rather than reducing it. Recommended fix: replace with either a real progress signal from the backend, or an explicit "this usually takes 15–20 seconds" message so the user knows to wait rather than wondering if something broke.

---

## Testing

Documentation only — no app code changed.

## User Story Covered

- US1: Menu Scanning (Customer) — [Issue #9](https://github.com/qianxuege/PickMyPlate2/issues/9)