### PR TITLE
feat(auto-dev-spec): add automated dev spec generation workflow triggered on PR merge

### DIFF
--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -15,8 +15,12 @@ permissions:
 jobs:
   generate:
     name: Generate or update dev spec
-    # Only run when the PR was actually merged (not just closed)
-    if: github.event.pull_request.merged == true
+    # Only run when the PR was actually merged AND has the 'user-story' label.
+    # The label requirement excludes test branches, doc branches, CI changes,
+    # and the auto-generated dev spec PRs themselves from triggering this workflow.
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'user-story')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -110,9 +110,9 @@ jobs:
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
           PR_DIFF_PATH: /tmp/pr.diff
-          CHANGED_FILES: ${{ join(github.event.pull_request.changed_files, ' ') }}
           EXISTING_SPEC_PATH: ${{ steps.paths.outputs.existing_spec }}
           DEV_SPEC_OUT_PATH: ${{ steps.paths.outputs.out_path }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Fetch the list of changed files via gh CLI
           gh pr view ${{ github.event.pull_request.number }} \
@@ -120,8 +120,6 @@ jobs:
             > /tmp/changed_files.txt
           export CHANGED_FILES=$(cat /tmp/changed_files.txt)
           node scripts/generateDevSpec.mjs
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Create dev spec branch, commit, and open PR
         if: steps.us.outputs.skip == 'false'

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -1,0 +1,185 @@
+name: Generate Dev Spec
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  generate:
+    name: Generate or update dev spec
+    # Only run when the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GEMINI_MODEL: ${{ secrets.GEMINI_MODEL }}
+      GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+      GCP_ACCESS_TOKEN: ${{ secrets.GCP_ACCESS_TOKEN }}
+      GCP_CREDENTIALS_JSON: ${{ secrets.GCP_CREDENTIALS_JSON }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      VERTEX_LOCATION: ${{ secrets.VERTEX_LOCATION }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use a PAT so the workflow can push commits back to the repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract user story number from branch name
+        id: us
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Match patterns like feat/us4-*, feature/us4-*, fix/us4-*
+          US_NUM=$(echo "$BRANCH" | grep -oP '(?i)us\K[0-9]+' | head -1)
+          if [ -z "$US_NUM" ]; then
+            echo "Branch '$BRANCH' does not match a user story pattern (us<N>). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "us_num=$US_NUM" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve dev spec output path
+        if: steps.us.outputs.skip == 'false'
+        id: paths
+        run: |
+          US_NUM="${{ steps.us.outputs.us_num }}"
+          SPEC_DIR="docs/dev-specs"
+          # Find existing spec for this user story (case-insensitive)
+          EXISTING=$(find "$SPEC_DIR" -iname "*us${US_NUM}*" -name "*.md" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "existing_spec=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "out_path=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "mode=update" >> "$GITHUB_OUTPUT"
+          else
+            SLUG=$(echo "${{ github.event.pull_request.head.ref }}" \
+              | sed 's|.*/||' \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed 's/[^a-z0-9-]/-/g' \
+              | sed 's/-\+/-/g')
+            echo "existing_spec=" >> "$GITHUB_OUTPUT"
+            echo "out_path=${SPEC_DIR}/us${US_NUM}-${SLUG}.md" >> "$GITHUB_OUTPUT"
+            echo "mode=create" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch PR diff
+        if: steps.us.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_API_URL: ${{ github.event.pull_request.url }}
+        run: |
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.v3.diff" \
+            "${PR_API_URL}" \
+            -o /tmp/pr.diff
+
+      - name: Run dev spec generator
+        if: steps.us.outputs.skip == 'false'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          PR_DIFF_PATH: /tmp/pr.diff
+          CHANGED_FILES: ${{ join(github.event.pull_request.changed_files, ' ') }}
+          EXISTING_SPEC_PATH: ${{ steps.paths.outputs.existing_spec }}
+          DEV_SPEC_OUT_PATH: ${{ steps.paths.outputs.out_path }}
+        run: |
+          # Fetch the list of changed files via gh CLI
+          gh pr view ${{ github.event.pull_request.number }} \
+            --json files --jq '[.files[].path] | join(" ")' \
+            > /tmp/changed_files.txt
+          export CHANGED_FILES=$(cat /tmp/changed_files.txt)
+          node scripts/generateDevSpec.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create dev spec branch, commit, and open PR
+        if: steps.us.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          US_NUM="${{ steps.us.outputs.us_num }}"
+          MODE="${{ steps.paths.outputs.mode }}"
+          SPEC_PATH="${{ steps.paths.outputs.out_path }}"
+          SOURCE_PR="${{ github.event.pull_request.number }}"
+          SOURCE_TITLE="${{ github.event.pull_request.title }}"
+          SPEC_BRANCH="docs/dev-spec-us${US_NUM}-pr${SOURCE_PR}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create a new branch for the dev spec
+          git checkout -b "$SPEC_BRANCH"
+
+          git add "$SPEC_PATH"
+          git commit -m "${MODE}: dev spec for US${US_NUM} — ${SOURCE_TITLE} (from PR #${SOURCE_PR})"
+
+          git push origin "$SPEC_BRANCH"
+
+          # Create GitHub Issue to track this dev spec
+          ISSUE_TITLE="${MODE^}: dev spec for US${US_NUM} — ${SOURCE_TITLE}"
+          ISSUE_BODY="## Dev Spec Tracking Issue
+
+          This issue tracks the $MODE of the development specification for US${US_NUM}.
+
+          **Relates to:** #${SOURCE_PR}
+          **Source PR:** ${SOURCE_TITLE}
+          **Mode:** ${MODE}
+          **Spec file:** \`${SPEC_PATH}\`
+
+          Generated automatically by the dev-spec workflow on merge of PR #${SOURCE_PR}."
+
+          ISSUE_URL=$(gh issue create \
+            --title "$ISSUE_TITLE" \
+            --body "$ISSUE_BODY")
+          ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oP '[0-9]+$')
+
+          # Amend commit to reference the issue
+          git commit --amend -m "${MODE}: dev spec for US${US_NUM} — ${SOURCE_TITLE} #${ISSUE_NUM}
+
+          Relates to #${SOURCE_PR}"
+          git push origin "$SPEC_BRANCH" --force-with-lease
+
+          # Open PR for the dev spec
+          gh pr create \
+            --title "${MODE^}: dev spec for US${US_NUM} — ${SOURCE_TITLE}" \
+            --body "## Summary
+
+          Auto-generated dev spec for US${US_NUM} triggered by the merge of PR #${SOURCE_PR}.
+
+          - **Mode:** ${MODE}
+          - **Spec file:** \`${SPEC_PATH}\`
+          - **Closes:** #${ISSUE_NUM}
+          - **Relates to:** #${SOURCE_PR}
+
+          Please review the generated spec for accuracy and completeness before merging.
+
+          🤖 Generated by the dev-spec workflow" \
+            --base main \
+            --head "$SPEC_BRANCH"

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -89,6 +89,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "us_num=$US_NUM" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -105,7 +106,7 @@ jobs:
             echo "out_path=$EXISTING" >> "$GITHUB_OUTPUT"
             echo "mode=update" >> "$GITHUB_OUTPUT"
           else
-            SLUG=$(echo "${{ github.event.pull_request.head.ref }}" \
+            SLUG=$(echo "${{ steps.us.outputs.branch }}" \
               | sed 's|.*/||' \
               | tr '[:upper:]' '[:lower:]' \
               | sed 's/[^a-z0-9-]/-/g' \

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -119,13 +119,11 @@ jobs:
         if: steps.us.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_API_URL: ${{ github.event.pull_request.url }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
         run: |
-          curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
+          gh api repos/${{ github.repository }}/pulls/${PR_NUMBER} \
             -H "Accept: application/vnd.github.v3.diff" \
-            "${PR_API_URL}" \
-            -o /tmp/pr.diff
+            > /tmp/pr.diff
 
       - name: Run dev spec generator
         if: steps.us.outputs.skip == 'false'

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -6,6 +6,12 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number of the merged user story implementation
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,12 +21,12 @@ permissions:
 jobs:
   generate:
     name: Generate or update dev spec
-    # Only run when the PR was actually merged AND has the 'user-story' label.
-    # The label requirement excludes test branches, doc branches, CI changes,
-    # and the auto-generated dev spec PRs themselves from triggering this workflow.
+    # On pull_request events: only run when merged AND has the 'user-story' label.
+    # On workflow_dispatch: always run (the human invoking it is confirming intent).
     if: |
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'user-story')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'user-story'))
 
     runs-on: ubuntu-latest
 
@@ -51,10 +57,27 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Load PR metadata (workflow_dispatch only)
+        id: pr
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number("${{ github.event.inputs.pr_number }}"),
+            });
+            core.setOutput("branch", pr.head.ref);
+            core.setOutput("title", pr.title);
+            core.setOutput("body", pr.body || "");
+            core.setOutput("url", pr.html_url);
+            core.setOutput("merged_at", pr.merged_at || "");
+
       - name: Extract user story number from branch name
         id: us
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.branch || github.event.pull_request.head.ref }}"
           # Match patterns like feat/us4-*, feature/us4-*, fix/us4-*
           US_NUM=$(echo "$BRANCH" | grep -oP '(?i)us\K[0-9]+' | head -1)
           if [ -z "$US_NUM" ]; then
@@ -103,12 +126,12 @@ jobs:
       - name: Run dev spec generator
         if: steps.us.outputs.skip == 'false'
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-          PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.title || github.event.pull_request.title }}
+          PR_BODY: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.body || github.event.pull_request.body }}
+          PR_URL: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.url || github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.branch || github.event.pull_request.head.ref }}
+          PR_MERGED_AT: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.merged_at || github.event.pull_request.merged_at }}
           PR_DIFF_PATH: /tmp/pr.diff
           EXISTING_SPEC_PATH: ${{ steps.paths.outputs.existing_spec }}
           DEV_SPEC_OUT_PATH: ${{ steps.paths.outputs.out_path }}
@@ -129,8 +152,8 @@ jobs:
           US_NUM="${{ steps.us.outputs.us_num }}"
           MODE="${{ steps.paths.outputs.mode }}"
           SPEC_PATH="${{ steps.paths.outputs.out_path }}"
-          SOURCE_PR="${{ github.event.pull_request.number }}"
-          SOURCE_TITLE="${{ github.event.pull_request.title }}"
+          SOURCE_PR="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}"
+          SOURCE_TITLE="${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.title || github.event.pull_request.title }}"
           SPEC_BRANCH="docs/dev-spec-us${US_NUM}-pr${SOURCE_PR}"
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -166,11 +166,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Save the generated spec before switching branches
+          cp "$SPEC_PATH" /tmp/generated-spec.md
+
           # Delete remote branch if it exists from a previous failed run
           git push origin --delete "$SPEC_BRANCH" 2>/dev/null || true
 
-          # Create a new branch for the dev spec
-          git checkout -b "$SPEC_BRANCH"
+          # Create the spec branch from main so the PR only contains the spec file
+          git fetch origin main
+          git checkout -b "$SPEC_BRANCH" origin/main
+
+          # Restore the generated spec
+          mkdir -p "$(dirname "$SPEC_PATH")"
+          cp /tmp/generated-spec.md "$SPEC_PATH"
 
           git add "$SPEC_PATH"
           git commit -m "${MODE}: dev spec for US${US_NUM} — ${SOURCE_TITLE} (from PR #${SOURCE_PR})"

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -106,11 +106,15 @@ jobs:
             echo "out_path=$EXISTING" >> "$GITHUB_OUTPUT"
             echo "mode=update" >> "$GITHUB_OUTPUT"
           else
-            SLUG=$(echo "${{ steps.us.outputs.branch }}" \
-              | sed 's|.*/||' \
+            # Derive slug from PR title — strip leading "completed user story N:" patterns then slugify
+            PR_TITLE="${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.title || github.event.pull_request.title }}"
+            SLUG=$(echo "$PR_TITLE" \
+              | sed -E 's/^(completed\s+)?user\s+story\s+[0-9]+[:\s-]*//I' \
               | tr '[:upper:]' '[:lower:]' \
-              | sed 's/[^a-z0-9-]/-/g' \
-              | sed 's/-\+/-/g')
+              | sed 's/[^a-z0-9]/-/g' \
+              | sed 's/-\+/-/g' \
+              | sed 's/^-\|-$//g' \
+              | cut -c1-60)
             echo "existing_spec=" >> "$GITHUB_OUTPUT"
             echo "out_path=${SPEC_DIR}/us${US_NUM}-${SLUG}.md" >> "$GITHUB_OUTPUT"
             echo "mode=create" >> "$GITHUB_OUTPUT"
@@ -161,6 +165,9 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Delete remote branch if it exists from a previous failed run
+          git push origin --delete "$SPEC_BRANCH" 2>/dev/null || true
 
           # Create a new branch for the dev spec
           git checkout -b "$SPEC_BRANCH"

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -61,19 +61,22 @@ jobs:
       - name: Load PR metadata (workflow_dispatch only)
         id: pr
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: Number("${{ github.event.inputs.pr_number }}"),
-            });
-            core.setOutput("branch", pr.head.ref);
-            core.setOutput("title", pr.title);
-            core.setOutput("body", pr.body || "");
-            core.setOutput("url", pr.html_url);
-            core.setOutput("merged_at", pr.merged_at || "");
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh pr view ${{ github.event.inputs.pr_number }} \
+            --repo ${{ github.repository }} \
+            --json headRefName,title,body,url,mergedAt)
+          echo "branch=$(echo "$PR_DATA"  | jq -r '.headRefName')"  >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_DATA"   | jq -r '.title')"        >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$PR_DATA"     | jq -r '.url')"          >> "$GITHUB_OUTPUT"
+          echo "merged_at=$(echo "$PR_DATA" | jq -r '.mergedAt // ""')" >> "$GITHUB_OUTPUT"
+          # body may be multi-line — write via delimiter
+          BODY=$(echo "$PR_DATA" | jq -r '.body // ""')
+          EOF_DELIM="EOF_$(openssl rand -hex 4)"
+          echo "body<<${EOF_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$BODY"              >> "$GITHUB_OUTPUT"
+          echo "${EOF_DELIM}"       >> "$GITHUB_OUTPUT"
 
       - name: Extract user story number from branch name
         id: us

--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GEMINI_MODEL: ${{ secrets.GEMINI_MODEL }}
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}

--- a/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
@@ -1,0 +1,133 @@
+You are a senior software engineer writing a development specification for a user story in the PickMyPlate project — a React Native / Expo mobile app with a Flask backend and Supabase (PostgreSQL + Auth + Storage).
+
+You are given:
+- The pull request title, body, and branch name
+- The unified diff of all code changes in the PR
+- The full content of every source file changed in the PR
+
+Your task is to produce a single, complete development specification in Markdown. Follow the exact section structure below. Be precise and derive all content from the code provided — do not invent APIs, classes, or behaviors that are not visible in the diff or source files. If information is genuinely unavailable (e.g., owners not mentioned), write "Unknown — leave blank for human to fill in."
+
+---
+
+## Required Sections
+
+### 1. Primary and Secondary Owners
+
+| Role | Name | Notes |
+|------|------|-------|
+| Primary owner | <from PR or commit history, else blank> | Owns requirements and release sign-off |
+| Secondary owner | <from PR or commit history, else blank> | Owns implementation review and test plan |
+
+---
+
+### 2. Date Merged into `main`
+
+State the merge date and link the PR number. Format: `YYYY-MM-DD (PR #N)`.
+
+---
+
+### 3. Architecture Diagram (Mermaid)
+
+Produce a `flowchart TB` diagram. Group components by where they execute:
+- `Client` — mobile device (Expo / React Native)
+- `Server` — Flask backend
+- `Cloud` — Supabase (Auth, PostgreSQL, Storage), Vertex AI / Gemini
+
+Show every component and module touched by this user story and the direction of their dependencies.
+
+---
+
+### 4. Information Flow Diagram (Mermaid)
+
+Produce a `flowchart LR` diagram showing which user data and application data moves between components, and in which direction. Label each arrow with the data being transferred.
+
+---
+
+### 5. Class Diagram (Mermaid)
+
+Produce a `classDiagram`. Because this is a TypeScript/React project, use UML stereotypes:
+- `<<component>>` for React components
+- `<<module>>` for TypeScript lib modules
+- `<<type>>` for TypeScript interfaces and types
+- `<<service>>` for Flask route modules
+
+Show all types, interfaces, components, and modules relevant to this user story and their relationships. Do not leave out any class, interface, or type visible in the source files provided.
+
+---
+
+### 6. Implementation Units
+
+For every TypeScript module, React component, and Python module relevant to this user story:
+
+- File path
+- Purpose
+- **Public fields and methods** (grouped by concept): name, type signature, purpose
+- **Private fields and methods** (grouped by concept): name, type signature, purpose
+
+---
+
+### 7. Technologies, Libraries, and APIs
+
+For every technology, library, framework, or external API used in this user story's implementation:
+
+| Technology | Version | Used for | Why chosen over alternatives | Source / Docs URL |
+|------------|---------|----------|------------------------------|-------------------|
+
+Do not omit language runtimes, common libraries, or tooling (e.g., TypeScript, Node.js, Jest, Expo SDK, Supabase JS client, Flask, Python).
+
+---
+
+### 8. Database — Long-Term Storage
+
+For every database table read or written by this user story:
+
+- Table name and purpose
+- Each column: name, type, purpose, estimated storage in bytes per row
+- Estimated total storage per user
+
+---
+
+### 9. Failure Scenarios
+
+For each of the following failure modes, describe the user-visible effect and the internally-visible effect:
+
+1. Frontend process crash
+2. Loss of all runtime state
+3. All stored data erased
+4. Corrupt data detected in the database
+5. Remote procedure call (API call) failed
+6. Client overloaded
+7. Client out of RAM
+8. Database out of storage space
+9. Network connectivity lost
+10. Database access lost
+11. Bot signs up and spams users
+
+---
+
+### 10. PII, Security, and Compliance
+
+List every piece of Personally Identifying Information (PII) stored in long-term storage for this user story.
+
+For each item:
+- What it is and why it must be stored
+- How it is stored (encrypted, hashed, plaintext)
+- How it entered the system (user input path → modules → fields → storage)
+- How it exits the system (storage → fields → modules → output path)
+- Who on the team is responsible for securing it
+- Procedures for auditing routine and non-routine access
+
+**Minor users:**
+- Does this feature solicit or store PII of users under 18?
+- If yes: does the app solicit guardian permission?
+- What is the team policy for ensuring minors' PII is not accessible by anyone convicted or suspected of child abuse?
+
+---
+
+## Style Rules
+
+- Use Mermaid code fences for all diagrams
+- Use tables for structured lists
+- Be specific: reference actual file paths, function names, table names, and column names from the code
+- Do not invent content — if something cannot be determined from the provided code, say so explicitly
+- Output pure Markdown only — no prose outside of section content

--- a/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
@@ -1,0 +1,61 @@
+You are a senior software engineer updating an existing development specification for a user story in the PickMyPlate project — a React Native / Expo mobile app with a Flask backend and Supabase (PostgreSQL + Auth + Storage).
+
+You are given:
+- The existing development specification (full Markdown)
+- The pull request title, body, and branch name for the update
+- The unified diff of all code changes in the new PR
+- The full content of every source file changed in the new PR
+
+Your task is to produce an updated development specification in Markdown. Apply only the changes that are justified by the new code — do not alter sections that are unaffected by this PR.
+
+---
+
+## Update Rules
+
+For each section, apply the following rules:
+
+### 1. Primary and Secondary Owners
+Update only if the PR or commit history explicitly names new owners. Otherwise preserve as-is.
+
+### 2. Date Merged into `main`
+Append the new merge date and PR number as an additional row or line. Do not remove the original entry. Format: `YYYY-MM-DD (PR #N)`.
+
+### 3. Architecture Diagram (Mermaid)
+Add, remove, or relabel nodes and edges only if the new diff introduces or removes components or changes their dependencies. Preserve unchanged parts exactly.
+
+### 4. Information Flow Diagram (Mermaid)
+Update arrows and labels only for data flows that changed or were added. Preserve unchanged flows.
+
+### 5. Class Diagram (Mermaid)
+Add new classes, interfaces, or relationships introduced by the PR. Remove entries only if the PR explicitly deletes them. Preserve everything else.
+
+### 6. Implementation Units
+Add new modules and components introduced by the PR. For modified modules, update only the fields and methods that changed. For deleted modules, remove their entries. Preserve unmodified entries exactly.
+
+### 7. Technologies, Libraries, and APIs
+Add new rows for any new dependency introduced by the PR (visible in `package.json`, `requirements.txt`, or import statements in the diff). Do not remove existing rows.
+
+### 8. Database — Long-Term Storage
+Add new tables or columns introduced by the PR (visible in migration files or Supabase schema changes). Update estimated storage if row structure changed. Preserve unmodified entries.
+
+### 9. Failure Scenarios
+Update failure scenario descriptions only if the PR changes behavior that affects how failures manifest. Preserve unmodified scenarios.
+
+### 10. PII, Security, and Compliance
+Add new PII entries if the PR stores new personal data. Update existing entries only if storage or access patterns changed. Never remove PII entries — mark them as deprecated instead if the data is no longer collected.
+
+---
+
+## Output
+
+Return the complete updated specification as a single Markdown document. Do not summarize the changes — output the full document so it can replace the existing file directly.
+
+---
+
+## Style Rules
+
+- Use Mermaid code fences for all diagrams
+- Use tables for structured lists
+- Be specific: reference actual file paths, function names, table names, and column names from the code
+- Do not invent content — if something cannot be determined from the provided code, say so explicitly
+- Output pure Markdown only — no prose outside of section content

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -1,0 +1,270 @@
+/**
+ * generateDevSpec.mjs
+ *
+ * Generates or updates a development specification for a user story
+ * by calling the Gemini API with the PR diff and changed source files.
+ *
+ * Environment variables (set by the GitHub Actions workflow):
+ *   PR_NUMBER        — pull request number
+ *   PR_TITLE         — pull request title
+ *   PR_BODY          — pull request body
+ *   PR_URL           — pull request HTML URL
+ *   PR_BRANCH        — head branch name (e.g. feat/us4-dish-filtering)
+ *   PR_MERGED_AT     — merge timestamp (ISO 8601)
+ *   PR_DIFF_PATH     — path to the unified diff file
+ *   CHANGED_FILES    — space-separated list of files changed in the PR
+ *   EXISTING_SPEC_PATH — path to existing dev spec (empty if creating new)
+ *   DEV_SPEC_OUT_PATH  — output path for the generated/updated spec
+ *   GEMINI_API_KEY   — Gemini API key (or use GCP_PROJECT + GCP_ACCESS_TOKEN)
+ *   GEMINI_MODEL     — model override (default: gemini-2.5-flash)
+ *   GCP_PROJECT      — GCP project (Vertex AI fallback)
+ *   GCP_ACCESS_TOKEN — GCP access token (Vertex AI fallback)
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const MAX_DIFF_CHARS = 80000;
+const MAX_SOURCE_CHARS = 60000;
+const DEFAULT_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
+const CREATE_PROMPT_PATH = "ai-workflows/DEV_SPEC_CREATE_PROMPT.md";
+const UPDATE_PROMPT_PATH = "ai-workflows/DEV_SPEC_UPDATE_PROMPT.md";
+
+async function main() {
+  const diffPath = process.env.PR_DIFF_PATH;
+  if (!diffPath) throw new Error("PR_DIFF_PATH is required.");
+
+  const outPath = process.env.DEV_SPEC_OUT_PATH;
+  if (!outPath) throw new Error("DEV_SPEC_OUT_PATH is required.");
+
+  const existingSpecPath = process.env.EXISTING_SPEC_PATH || "";
+  const isUpdate = existingSpecPath !== "" && await fileExists(existingSpecPath);
+
+  const [diff, sourceContext, promptTemplate, existingSpec] = await Promise.all([
+    fs.readFile(diffPath, "utf8"),
+    buildSourceContext(),
+    fs.readFile(isUpdate ? UPDATE_PROMPT_PATH : CREATE_PROMPT_PATH, "utf8"),
+    isUpdate ? fs.readFile(existingSpecPath, "utf8") : Promise.resolve(""),
+  ]);
+
+  const prompt = buildPrompt(promptTemplate, diff, sourceContext, existingSpec, isUpdate);
+  process.stdout.write(`Calling Gemini (${isUpdate ? "update" : "create"} mode)...\n`);
+
+  const specMarkdown = await callGemini(prompt);
+
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, specMarkdown);
+  process.stdout.write(`Dev spec written to ${outPath}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt assembly
+// ---------------------------------------------------------------------------
+
+function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate) {
+  const metadata = {
+    prNumber: process.env.PR_NUMBER || "",
+    prTitle: process.env.PR_TITLE || "",
+    prBody: process.env.PR_BODY || "",
+    prUrl: process.env.PR_URL || "",
+    prBranch: process.env.PR_BRANCH || "",
+    mergedAt: process.env.PR_MERGED_AT || "",
+  };
+
+  const truncatedDiff =
+    diff.length > MAX_DIFF_CHARS
+      ? `${diff.slice(0, MAX_DIFF_CHARS)}\n\n[diff truncated — ${diff.length} total chars]`
+      : diff;
+
+  const parts = [
+    template,
+    "",
+    "---",
+    "",
+    "## Pull Request Metadata",
+    "",
+    "```json",
+    JSON.stringify(metadata, null, 2),
+    "```",
+    "",
+    "## Unified Diff",
+    "",
+    "```diff",
+    truncatedDiff,
+    "```",
+    "",
+    "## Changed Source Files",
+    "",
+    sourceContext,
+  ];
+
+  if (isUpdate && existingSpec) {
+    parts.push(
+      "",
+      "## Existing Development Specification",
+      "",
+      existingSpec,
+    );
+  }
+
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Source file context
+// ---------------------------------------------------------------------------
+
+async function buildSourceContext() {
+  const changedFiles = (process.env.CHANGED_FILES || "")
+    .split(/\s+/)
+    .map((f) => f.trim())
+    .filter((f) => f && isSourceFile(f));
+
+  if (changedFiles.length === 0) return "(no source files identified)";
+
+  let totalChars = 0;
+  const sections = [];
+
+  for (const filePath of changedFiles) {
+    if (totalChars >= MAX_SOURCE_CHARS) {
+      sections.push(`\n[source context truncated — ${changedFiles.length} files total]\n`);
+      break;
+    }
+    try {
+      const content = await fs.readFile(filePath, "utf8");
+      const excerpt =
+        totalChars + content.length > MAX_SOURCE_CHARS
+          ? content.slice(0, MAX_SOURCE_CHARS - totalChars) + "\n[file truncated]"
+          : content;
+      sections.push(`### ${filePath}\n\n\`\`\`\n${excerpt}\n\`\`\``);
+      totalChars += excerpt.length;
+    } catch {
+      sections.push(`### ${filePath}\n\n(could not read file)`);
+    }
+  }
+
+  return sections.join("\n\n");
+}
+
+function isSourceFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return [".ts", ".tsx", ".js", ".mjs", ".py", ".sql"].includes(ext);
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gemini API calls (mirrors llmReview.mjs)
+// ---------------------------------------------------------------------------
+
+async function callGemini(prompt) {
+  if (process.env.GEMINI_API_KEY) return callGeminiApi(prompt);
+  if (process.env.GCP_PROJECT) {
+    const accessToken =
+      process.env.GCP_ACCESS_TOKEN || (await getServiceAccountAccessToken());
+    if (!accessToken) throw new Error("Missing Google Cloud auth.");
+    process.env.GCP_ACCESS_TOKEN = accessToken;
+    return callVertexGemini(prompt);
+  }
+  throw new Error("Missing Gemini credentials. Set GEMINI_API_KEY or GCP_PROJECT.");
+}
+
+async function callGeminiApi(prompt) {
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${DEFAULT_MODEL}:generateContent?key=${encodeURIComponent(process.env.GEMINI_API_KEY)}`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.2 },
+    }),
+  });
+  return extractText(await parseResponse(response, "Gemini API"));
+}
+
+async function callVertexGemini(prompt) {
+  const location = process.env.VERTEX_LOCATION || "us-central1";
+  const endpoint = `https://${location}-aiplatform.googleapis.com/v1/projects/${encodeURIComponent(process.env.GCP_PROJECT)}/locations/${encodeURIComponent(location)}/publishers/google/models/${DEFAULT_MODEL}:generateContent`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.GCP_ACCESS_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.2 },
+    }),
+  });
+  return extractText(await parseResponse(response, "Vertex AI"));
+}
+
+async function parseResponse(response, provider) {
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(`${provider} request failed with ${response.status}: ${JSON.stringify(payload)}`);
+  }
+  return payload;
+}
+
+function extractText(payload) {
+  const text = payload?.candidates?.[0]?.content?.parts
+    ?.map((p) => p.text || "")
+    .join("")
+    .trim();
+  if (!text) throw new Error("Gemini returned no text content.");
+  // Strip markdown code fences if the model wrapped the whole output
+  const fenced = text.match(/^```(?:markdown)?\s*([\s\S]*?)```\s*$/i);
+  return fenced ? fenced[1].trim() : text;
+}
+
+async function getServiceAccountAccessToken() {
+  if (!process.env.GCP_CREDENTIALS_JSON) return "";
+  const credentials = JSON.parse(process.env.GCP_CREDENTIALS_JSON);
+  const now = Math.floor(Date.now() / 1000);
+  const tokenUri = credentials.token_uri || "https://oauth2.googleapis.com/token";
+  const scope = "https://www.googleapis.com/auth/cloud-platform";
+  const assertion = signJwt(
+    { iss: credentials.client_email, sub: credentials.client_email, aud: tokenUri, iat: now, exp: now + 3600, scope },
+    credentials.private_key,
+  );
+  const body = new URLSearchParams({ grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion });
+  const response = await fetch(tokenUri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(`OAuth token exchange failed: ${JSON.stringify(payload)}`);
+  return payload.access_token || "";
+}
+
+function signJwt(claims, privateKeyPem) {
+  const header = { alg: "RS256", typ: "JWT" };
+  const enc = (v) => base64UrlEncode(JSON.stringify(v));
+  const signer = crypto.createSign("RSA-SHA256");
+  signer.update(`${enc(header)}.${enc(claims)}`);
+  signer.end();
+  return `${enc(header)}.${enc(claims)}.${base64UrlEncode(signer.sign(privateKeyPem))}`;
+}
+
+function base64UrlEncode(value) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack || err.message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dev-spec.yml` — triggers on every PR merged to `main` whose branch matches a `us<N>` pattern; auto-detects create vs. update mode; opens a GitHub Issue and a review PR for the generated spec
- Adds `scripts/generateDevSpec.mjs` — calls Gemini (Vertex AI) with the PR diff + changed source files to generate the dev spec markdown
- Adds `ai-workflows/DEV_SPEC_CREATE_PROMPT.md` — prompt for generating a new dev spec covering all 10 required sections
- Adds `ai-workflows/DEV_SPEC_UPDATE_PROMPT.md` — prompt for updating an existing spec after a follow-up PR, with per-section preserve/update rules

## How it works
1. A feature PR targeting `main` is merged (e.g. `feat/us4-dish-filtering`)
2. The workflow extracts the user story number from the branch name
3. It checks whether a dev spec already exists for that US number — selects create or update prompt accordingly
4. Calls Gemini with the PR diff + source file contents
5. Creates a new branch `docs/dev-spec-us<N>-pr<M>`, commits the spec, opens a GitHub Issue linked to the source PR, and opens a review PR

## Test plan
- [ ] Merge a feature PR with a `us<N>` branch name and confirm the workflow triggers
- [ ] Confirm the generated spec PR and issue are created correctly
- [ ] Verify secrets (`GCP_PROJECT`, `GEMINI_MODEL`, etc.) are already present — confirmed via `gh secret list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)