### PR TITLE
Completed User Story 10: Add personal notes to favorited dishes

### DIFF
--- a/app/diner-favorites.tsx
+++ b/app/diner-favorites.tsx
@@ -21,6 +21,8 @@ import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import {
   fetchDinerFavoritesList,
   toggleDishFavorite,
+  upsertFavoriteNote,
+  NOTE_MAX_LENGTH,
   type DinerFavoriteListItem,
 } from '@/lib/diner-favorites';
 
@@ -81,6 +83,10 @@ export default function DinerFavoritesScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [collapsedRestaurants, setCollapsedRestaurants] = useState<Set<string>>(() => new Set());
+  const [editingNoteForDishId, setEditingNoteForDishId] = useState<string | null>(null);
+  const [noteInputs, setNoteInputs] = useState<Map<string, string>>(() => new Map());
+  const [notes, setNotes] = useState<Map<string, string | null>>(() => new Map());
+  const [savingNote, setSavingNote] = useState(false);
 
   const filteredItems = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -122,6 +128,7 @@ export default function DinerFavoritesScreen() {
     try {
       const list = await fetchDinerFavoritesList();
       setItems(list);
+      setNotes(new Map(list.map((item) => [item.dishId, item.note])));
     } catch (e) {
       Alert.alert('Could not load favorites', e instanceof Error ? e.message : 'Unknown error');
     } finally {
@@ -168,6 +175,134 @@ export default function DinerFavoritesScreen() {
     },
     []
   );
+
+  const onSaveNote = useCallback(
+    async (dishId: string) => {
+      const text = noteInputs.get(dishId) ?? '';
+      setSavingNote(true);
+      try {
+        await upsertFavoriteNote(dishId, text);
+        setNotes((prev) => {
+          const next = new Map(prev);
+          next.set(dishId, text.trim().length > 0 ? text.trim() : null);
+          return next;
+        });
+        setEditingNoteForDishId(null);
+      } catch (e) {
+        Alert.alert('Could not save note', e instanceof Error ? e.message : 'Unknown error');
+      } finally {
+        setSavingNote(false);
+      }
+    },
+    [noteInputs]
+  );
+
+  const renderNoteWidget = (row: DinerFavoriteListItem) => {
+    const savedNote = notes.get(row.dishId) ?? null;
+    const isEditing = editingNoteForDishId === row.dishId;
+    const inputText = noteInputs.get(row.dishId) ?? savedNote ?? '';
+    const charCount = inputText.length;
+    const overLimit = charCount > NOTE_MAX_LENGTH;
+
+    if (isEditing) {
+      return (
+        <View style={styles.noteEditWrap}>
+          <TextInput
+            value={inputText}
+            onChangeText={(text) =>
+              setNoteInputs((prev) => {
+                const next = new Map(prev);
+                next.set(row.dishId, text);
+                return next;
+              })
+            }
+            placeholder="Add a private note…"
+            placeholderTextColor={FIG.sub}
+            style={[styles.noteInput, overLimit && styles.noteInputError]}
+            multiline
+            maxLength={NOTE_MAX_LENGTH + 20}
+            autoFocus
+            accessibilityLabel="Note text input"
+          />
+          <View style={styles.noteEditFooter}>
+            <Text style={[styles.noteCharCount, overLimit && styles.noteCharCountError]}>
+              {charCount} / {NOTE_MAX_LENGTH}
+            </Text>
+            <View style={styles.noteEditButtons}>
+              <Pressable
+                onPress={() => {
+                  setEditingNoteForDishId(null);
+                  setNoteInputs((prev) => {
+                    const next = new Map(prev);
+                    next.delete(row.dishId);
+                    return next;
+                  });
+                }}
+                style={({ pressed }) => [styles.noteCancelButton, pressed && styles.iconPressed]}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel note edit"
+              >
+                <Text style={styles.noteCancelText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => void onSaveNote(row.dishId)}
+                disabled={savingNote || overLimit}
+                style={({ pressed }) => [
+                  styles.noteSaveButton,
+                  (savingNote || overLimit) && styles.noteSaveButtonDisabled,
+                  pressed && !savingNote && !overLimit && styles.iconPressed,
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Save note"
+              >
+                <Text style={styles.noteSaveText}>{savingNote ? 'Saving…' : 'Save'}</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      );
+    }
+
+    if (savedNote) {
+      return (
+        <Pressable
+          onPress={() => {
+            setNoteInputs((prev) => {
+              const next = new Map(prev);
+              next.set(row.dishId, savedNote);
+              return next;
+            });
+            setEditingNoteForDishId(row.dishId);
+          }}
+          style={({ pressed }) => [styles.noteSavedWrap, pressed && styles.dishRowPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Edit note"
+        >
+          <MaterialCommunityIcons name="pencil-outline" size={14} color={FIG.sub} style={styles.noteIcon} />
+          <Text style={styles.noteSavedText} numberOfLines={2}>{savedNote}</Text>
+        </Pressable>
+      );
+    }
+
+    return (
+      <Pressable
+        onPress={() => {
+          setNoteInputs((prev) => {
+            const next = new Map(prev);
+            next.set(row.dishId, '');
+            return next;
+          });
+          setEditingNoteForDishId(row.dishId);
+        }}
+        style={({ pressed }) => [styles.noteAddWrap, pressed && styles.dishRowPressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Add a private note to this dish"
+      >
+        <MaterialCommunityIcons name="pencil-plus-outline" size={14} color={FIG.sub} />
+        <Text style={styles.noteAddText}>Add a private note…</Text>
+      </Pressable>
+    );
+  };
 
   const renderFlames = (level: 0 | 1 | 2 | 3) => {
     if (level === 0) return null;
@@ -235,6 +370,7 @@ export default function DinerFavoritesScreen() {
         >
           <MaterialCommunityIcons name="heart" size={22} color={FIG.orange} />
         </Pressable>
+        {renderNoteWidget(row)}
       </View>
     );
   };
@@ -518,5 +654,106 @@ const styles = StyleSheet.create({
   },
   iconPressed: {
     opacity: 0.7,
+  },
+  noteEditWrap: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    gap: 8,
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderColor: FIG.border,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    lineHeight: 20,
+    color: FIG.text,
+    backgroundColor: '#FAFAFA',
+    minHeight: 72,
+    textAlignVertical: 'top' as const,
+  },
+  noteInputError: {
+    borderColor: '#E53E3E',
+  },
+  noteEditFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  noteCharCount: {
+    fontSize: 12,
+    lineHeight: 16,
+    color: FIG.sub,
+  },
+  noteCharCountError: {
+    color: '#E53E3E',
+  },
+  noteEditButtons: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  noteCancelButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: FIG.border,
+    backgroundColor: Colors.white,
+  },
+  noteCancelText: {
+    fontSize: 14,
+    fontWeight: '500' as const,
+    color: FIG.bodyMuted,
+  },
+  noteSaveButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: FIG.orange,
+  },
+  noteSaveButtonDisabled: {
+    opacity: 0.5,
+  },
+  noteSaveText: {
+    fontSize: 14,
+    fontWeight: '600' as const,
+    color: Colors.white,
+  },
+  noteSavedWrap: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginHorizontal: 16,
+    marginBottom: 12,
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    backgroundColor: '#F8FAFC',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: FIG.border,
+  },
+  noteIcon: {
+    marginTop: 2,
+  },
+  noteSavedText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+    color: FIG.bodyMuted,
+  },
+  noteAddWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  noteAddText: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: FIG.sub,
   },
 });

--- a/app/dish/[dishId].tsx
+++ b/app/dish/[dishId].tsx
@@ -9,6 +9,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -19,7 +20,13 @@ import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import { generateDishImage } from '@/lib/dish-image-api';
 import type { DinerPreferenceSnapshot } from '@/lib/diner-preferences';
 import { fetchDinerPreferences, spiceDbToLabel } from '@/lib/diner-preferences';
-import { isDishFavorited, toggleDishFavorite } from '@/lib/diner-favorites';
+import {
+  isDishFavorited,
+  toggleDishFavorite,
+  fetchFavoriteNote,
+  upsertFavoriteNote,
+  NOTE_MAX_LENGTH,
+} from '@/lib/diner-favorites';
 import type { DinerScannedDishRow } from '@/lib/menu-scan-schema';
 import { supabase } from '@/lib/supabase';
 
@@ -227,6 +234,10 @@ export default function DishDetailScreen() {
   const [favorite, setFavorite] = useState(false);
   const [imageLoading, setImageLoading] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [noteInput, setNoteInput] = useState('');
+  const [editingNote, setEditingNote] = useState(false);
+  const [savingNote, setSavingNote] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -325,6 +336,14 @@ export default function DishDetailScreen() {
         try {
           const fav = await isDishFavorited(typedRow.id);
           if (!cancelled) setFavorite(fav);
+          if (fav && !cancelled) {
+            try {
+              const existingNote = await fetchFavoriteNote(typedRow.id);
+              if (!cancelled) setNote(existingNote);
+            } catch {
+              // non-critical — note load failure doesn't block the page
+            }
+          }
         } catch {
           if (!cancelled) setFavorite(false);
         }
@@ -466,6 +485,11 @@ export default function DishDetailScreen() {
                       try {
                         const next = await toggleDishFavorite(detail.id);
                         setFavorite(next);
+                        if (!next) {
+                          setNote(null);
+                          setNoteInput('');
+                          setEditingNote(false);
+                        }
                       } catch (err) {
                         Alert.alert(
                           'Favorites',
@@ -560,6 +584,95 @@ export default function DishDetailScreen() {
                       </View>
                     ))}
                   </View>
+                </View>
+              )}
+
+              {favorite && (
+                <View style={styles.section}>
+                  <View style={styles.noteSectionHeader}>
+                    <Text style={styles.sectionTitle}>My Note</Text>
+                    {!editingNote && (
+                      <Pressable
+                        onPress={() => {
+                          setNoteInput(note ?? '');
+                          setEditingNote(true);
+                        }}
+                        style={({ pressed }) => [styles.noteEditButton, pressed && styles.favoriteButtonPressed]}
+                        accessibilityRole="button"
+                        accessibilityLabel={note ? 'Edit note' : 'Add note'}
+                      >
+                        <MaterialCommunityIcons name="pencil-outline" size={16} color={FIG.muted} />
+                        <Text style={styles.noteEditButtonText}>{note ? 'Edit' : 'Add'}</Text>
+                      </Pressable>
+                    )}
+                  </View>
+
+                  {editingNote ? (
+                    <View style={styles.noteEditWrap}>
+                      <TextInput
+                        value={noteInput}
+                        onChangeText={setNoteInput}
+                        placeholder="Add a private note…"
+                        placeholderTextColor={FIG.muted}
+                        style={[styles.noteInput, noteInput.length > NOTE_MAX_LENGTH && styles.noteInputError]}
+                        multiline
+                        maxLength={NOTE_MAX_LENGTH + 20}
+                        autoFocus
+                        accessibilityLabel="Note text input"
+                      />
+                      <View style={styles.noteEditFooter}>
+                        <Text style={[styles.noteCharCount, noteInput.length > NOTE_MAX_LENGTH && styles.noteCharCountError]}>
+                          {noteInput.length} / {NOTE_MAX_LENGTH}
+                        </Text>
+                        <View style={styles.noteEditButtons}>
+                          <Pressable
+                            onPress={() => {
+                              setNoteInput(note ?? '');
+                              setEditingNote(false);
+                            }}
+                            style={({ pressed }) => [styles.noteCancelButton, pressed && styles.favoriteButtonPressed]}
+                            accessibilityRole="button"
+                            accessibilityLabel="Cancel"
+                          >
+                            <Text style={styles.noteCancelText}>Cancel</Text>
+                          </Pressable>
+                          <Pressable
+                            onPress={() => {
+                              void (async () => {
+                                if (noteInput.length > NOTE_MAX_LENGTH || savingNote) return;
+                                setSavingNote(true);
+                                try {
+                                  await upsertFavoriteNote(detail.id, noteInput);
+                                  setNote(noteInput.trim().length > 0 ? noteInput.trim() : null);
+                                  setEditingNote(false);
+                                } catch (err) {
+                                  Alert.alert('Could not save note', err instanceof Error ? err.message : 'Unknown error');
+                                } finally {
+                                  setSavingNote(false);
+                                }
+                              })();
+                            }}
+                            disabled={savingNote || noteInput.length > NOTE_MAX_LENGTH}
+                            style={({ pressed }) => [
+                              styles.noteSaveButton,
+                              (savingNote || noteInput.length > NOTE_MAX_LENGTH) && styles.noteSaveButtonDisabled,
+                              pressed && styles.favoriteButtonPressed,
+                            ]}
+                            accessibilityRole="button"
+                            accessibilityLabel="Save note"
+                          >
+                            <Text style={styles.noteSaveText}>{savingNote ? 'Saving…' : 'Save'}</Text>
+                          </Pressable>
+                        </View>
+                      </View>
+                    </View>
+                  ) : note ? (
+                    <View style={styles.noteSavedCard}>
+                      <Text style={styles.noteSavedText}>{note}</Text>
+                    </View>
+                  ) : (
+                    <Text style={styles.placeholderText}>No note yet. Tap Add to jot something down.</Text>
+                  )}
                 </View>
               )}
             </View>
@@ -834,5 +947,100 @@ const styles = StyleSheet.create({
     flex: 1,
     ...Typography.body,
     color: FIG.greenText,
+  },
+  noteSectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  noteEditButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: FIG.border,
+  },
+  noteEditButtonText: {
+    fontSize: 13,
+    fontWeight: '500' as const,
+    color: FIG.muted,
+  },
+  noteEditWrap: {
+    gap: 8,
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderColor: FIG.border,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    lineHeight: 20,
+    color: FIG.text,
+    backgroundColor: FIG.cardBg,
+    minHeight: 80,
+    textAlignVertical: 'top' as const,
+  },
+  noteInputError: {
+    borderColor: Colors.error,
+  },
+  noteEditFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  noteCharCount: {
+    fontSize: 12,
+    lineHeight: 16,
+    color: FIG.muted,
+  },
+  noteCharCountError: {
+    color: Colors.error,
+  },
+  noteEditButtons: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  noteCancelButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: FIG.border,
+    backgroundColor: Colors.white,
+  },
+  noteCancelText: {
+    fontSize: 14,
+    fontWeight: '500' as const,
+    color: FIG.sub,
+  },
+  noteSaveButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: dinerRoleTheme.primary,
+  },
+  noteSaveButtonDisabled: {
+    opacity: 0.5,
+  },
+  noteSaveText: {
+    fontSize: 14,
+    fontWeight: '600' as const,
+    color: Colors.white,
+  },
+  noteSavedCard: {
+    backgroundColor: FIG.cardBg,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: FIG.border,
+    padding: 14,
+  },
+  noteSavedText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: FIG.sub,
   },
 });

--- a/lib/diner-favorites.ts
+++ b/lib/diner-favorites.ts
@@ -225,6 +225,10 @@ export async function upsertFavoriteNote(dishId: string, note: string): Promise<
   if (!user) throw new Error('Sign in required');
 
   const trimmed = note.trim();
+  if (trimmed.length > NOTE_MAX_LENGTH) {
+    throw new Error(`Notes must be ${NOTE_MAX_LENGTH} characters or fewer.`);
+  }
+
   const { error } = await supabase
     .from('diner_favorite_dishes')
     .update({ note: trimmed.length > 0 ? trimmed : null })

--- a/lib/diner-favorites.ts
+++ b/lib/diner-favorites.ts
@@ -13,7 +13,10 @@ export type DinerFavoriteListItem = {
   priceDisplay: string | null;
   spiceLevel: 0 | 1 | 2 | 3;
   imageUrl: string | null;
+  note: string | null;
 };
+
+export const NOTE_MAX_LENGTH = 300;
 
 /**
  * All favorited dish ids for the signed-in diner (for menu/search hearts).
@@ -95,7 +98,7 @@ export async function fetchDinerFavoritesList(): Promise<DinerFavoriteListItem[]
 
   const { data: favs, error: favErr } = await supabase
     .from('diner_favorite_dishes')
-    .select('dish_id, created_at')
+    .select('dish_id, created_at, note')
     .eq('profile_id', user.id)
     .order('created_at', { ascending: false });
 
@@ -183,8 +186,50 @@ export async function fetchDinerFavoritesList(): Promise<DinerFavoriteListItem[]
       priceDisplay: (d.price_display as string | null) ?? null,
       spiceLevel: (d.spice_level ?? 0) as 0 | 1 | 2 | 3,
       imageUrl: (d.image_url as string | null) ?? null,
+      note: (f.note as string | null) ?? null,
     });
   }
 
   return out;
+}
+
+/**
+ * Fetch the note for a single favorited dish (used on the dish detail page).
+ * Returns null if not favorited or no note set.
+ */
+export async function fetchFavoriteNote(dishId: string): Promise<string | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from('diner_favorite_dishes')
+    .select('note')
+    .eq('profile_id', user.id)
+    .eq('dish_id', dishId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return (data?.note as string | null) ?? null;
+}
+
+/**
+ * Save or clear a note on a favorited dish.
+ * Passing an empty string clears the note (sets to null).
+ */
+export async function upsertFavoriteNote(dishId: string, note: string): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Sign in required');
+
+  const trimmed = note.trim();
+  const { error } = await supabase
+    .from('diner_favorite_dishes')
+    .update({ note: trimmed.length > 0 ? trimmed : null })
+    .eq('profile_id', user.id)
+    .eq('dish_id', dishId);
+
+  if (error) throw new Error(error.message);
 }

--- a/supabase/migrations/20260416052648_us10_favorite_dish_notes.sql
+++ b/supabase/migrations/20260416052648_us10_favorite_dish_notes.sql
@@ -1,0 +1,4 @@
+-- US10: Add personal notes to favorited dishes
+-- Adds a nullable `note` column to diner_favorite_dishes.
+-- Notes are private (scoped by profile_id) and enforced to 300 chars at the app layer.
+ALTER TABLE diner_favorite_dishes ADD COLUMN note text;

--- a/supabase/migrations/20260416052648_us10_favorite_dish_notes.sql
+++ b/supabase/migrations/20260416052648_us10_favorite_dish_notes.sql
@@ -1,4 +1,8 @@
 -- US10: Add personal notes to favorited dishes
 -- Adds a nullable `note` column to diner_favorite_dishes.
--- Notes are private (scoped by profile_id) and enforced to 300 chars at the app layer.
+-- Notes are private (scoped by profile_id) and enforced to 300 chars.
 ALTER TABLE diner_favorite_dishes ADD COLUMN note text;
+
+ALTER TABLE diner_favorite_dishes
+  ADD CONSTRAINT diner_favorite_dishes_note_length_check
+  CHECK (note IS NULL OR char_length(note) <= 300);

--- a/supabase/migrations/20260416055019_us10_favorite_dish_notes_update_policy.sql
+++ b/supabase/migrations/20260416055019_us10_favorite_dish_notes_update_policy.sql
@@ -1,0 +1,14 @@
+-- US10: Allow diners to update their own favorite dish rows (needed to save notes).
+-- The original migration only created SELECT, INSERT, and DELETE policies.
+-- Without an UPDATE policy, note saves are silently ignored by RLS.
+create policy "diner_favorite_dishes_update_own"
+  on public.diner_favorite_dishes
+  for update
+  to authenticated
+  using (
+    profile_id = (select auth.uid())
+    and public.is_diner((select auth.uid()))
+  )
+  with check (
+    profile_id = (select auth.uid())
+  );


### PR DESCRIPTION
Closes #77
https://github.com/qianxuege/PickMyPlate2/issues/77

## Summary
- Diners can add, edit, and delete a private note (max 300 chars) on any favorited dish
- Notes appear inline on the Favorites list and in a "My Note" section on the Dish Detail page
- Notes persist via a new `note` column on `diner_favorite_dishes`; fixed missing UPDATE RLS policy that silently blocked saves

## Changes
- `lib/diner-favorites.ts` — `note` field on type; `fetchFavoriteNote`, `upsertFavoriteNote`, `NOTE_MAX_LENGTH`
- `app/diner-favorites.tsx` — inline note widget (add / edit / display) per dish row
- `app/dish/[dishId].tsx` — "My Note" section shown only when dish is favorited
- `supabase/migrations` — `note text` column + UPDATE RLS policy

## Machine Acceptance Criteria
- Note saved and linked to user + dish ✅
- Note displayed on favorites list and dish page ✅
- Edit and delete persist ✅
- Max 300 chars enforced at input (Save disabled over limit) ✅
- Notes are private (all queries scoped by `profile_id`) ✅

## Human Acceptance Criteria
- Inline UX — no modals, no separate screen ✅
- Lightweight text box under each favorited dish ✅
- "My Note" label; no public-facing UI ✅
- Saving empty text clears the note ✅

## Test Notes
- Validated note save/edit/reload on both Favorites list and Dish Detail page
- Fixed RLS bug: `diner_favorite_dishes` lacked an UPDATE policy, causing silent save failures