### PR TITLE
fix(dev-spec): use correct PR number on workflow_dispatch when fetching changed files

### DIFF
--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -145,7 +145,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Fetch the list of changed files via gh CLI
-          gh pr view ${{ github.event.pull_request.number }} \
+          PR_NUM="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}"
+          gh pr view "$PR_NUM" \
+            --repo ${{ github.repository }} \
             --json files --jq '[.files[].path] | join(" ")' \
             > /tmp/changed_files.txt
           export CHANGED_FILES=$(cat /tmp/changed_files.txt)


### PR DESCRIPTION
## Summary
- Fixes a bug where `gh pr view` used `github.event.pull_request.number` (empty on `workflow_dispatch`) instead of `github.event.inputs.pr_number`, causing the error: `no pull requests found for branch "main"`

## Root cause
The "Run dev spec generator" step hardcoded `${{ github.event.pull_request.number }}` when fetching the list of changed files. This is `null` on manual `workflow_dispatch` triggers, so `gh` defaulted to looking for a PR on the current branch (`main`) and failed.

## Fix
Resolve the PR number from the correct source for each event type — `github.event.inputs.pr_number` for `workflow_dispatch`, `github.event.pull_request.number` for automatic triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)