### PR TITLE
feat(dev-spec): add Mermaid readability rules and linked issue owner extraction

### DIFF
--- a/.github/workflows/dev-spec.yml
+++ b/.github/workflows/dev-spec.yml
@@ -143,6 +143,7 @@ jobs:
           EXISTING_SPEC_PATH: ${{ steps.paths.outputs.existing_spec }}
           DEV_SPEC_OUT_PATH: ${{ steps.paths.outputs.out_path }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Fetch the list of changed files via gh CLI
           PR_NUM="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event.pull_request.number }}"

--- a/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
@@ -15,8 +15,8 @@ Your task is to produce a single, complete development specification in Markdown
 
 | Role | Name | Notes |
 |------|------|-------|
-| Primary owner | <from PR or commit history, else blank> | Owns requirements and release sign-off |
-| Secondary owner | <from PR or commit history, else blank> | Owns implementation review and test plan |
+| Primary owner | <extract from the Linked User Story Issue section below — look for "Primary Owner:" line> | Owns requirements and release sign-off |
+| Secondary owner | <extract from the Linked User Story Issue section below — look for "Secondary Owner:" line> | Owns implementation review and test plan |
 
 ---
 
@@ -28,18 +28,33 @@ State the merge date and link the PR number. Format: `YYYY-MM-DD (PR #N)`.
 
 ### 3. Architecture Diagram (Mermaid)
 
-Produce a `flowchart TB` diagram. Group components by where they execute:
+Produce a `flowchart TB` diagram grouped by execution layer using subgraphs:
 - `Client` — mobile device (Expo / React Native)
 - `Server` — Flask backend
 - `Cloud` — Supabase (Auth, PostgreSQL, Storage), Vertex AI / Gemini
 
-Show every component and module touched by this user story and the direction of their dependencies.
+**Readability rules:**
+- Limit each diagram to **12 nodes or fewer**
+- If more than 12 components are involved, split into two diagrams:
+  - **3a. Client-side architecture** — components and lib modules only
+  - **3b. Backend and cloud architecture** — server, database, and cloud services only
+- Use short node labels (filename stem only, e.g. `restaurant-ingredient-items` not the full path)
+- Always use `flowchart TB` — never `LR`
+- Prefer 2–3 levels of depth; avoid chains longer than 4 nodes
 
 ---
 
 ### 4. Information Flow Diagram (Mermaid)
 
-Produce a `flowchart LR` diagram showing which user data and application data moves between components, and in which direction. Label each arrow with the data being transferred.
+Split into two focused diagrams:
+- **4a. Write path** — how user input travels from UI → lib → database
+- **4b. Read path** — how data travels from database → lib → UI
+
+Each diagram:
+- Uses `flowchart TB`
+- Has **8 nodes or fewer**
+- Labels each arrow with the data field or payload being transferred (keep labels under 40 characters)
+- Groups nodes into subgraphs by layer: `UI`, `Lib`, `Database`
 
 ---
 
@@ -51,7 +66,13 @@ Produce a `classDiagram`. Because this is a TypeScript/React project, use UML st
 - `<<type>>` for TypeScript interfaces and types
 - `<<service>>` for Flask route modules
 
-Show all types, interfaces, components, and modules relevant to this user story and their relationships. Do not leave out any class, interface, or type visible in the source files provided.
+**Readability rules:**
+- Limit each diagram to **8 classes or fewer**
+- If more than 8 are relevant, split into two diagrams:
+  - **5a. Data types and schemas** — interfaces, types, and Zod schemas
+  - **5b. Components and modules** — React components and lib modules
+- List at most **5 members per class** — include only the most significant public fields and methods
+- Do not leave out any class, interface, or type — include them all, split across diagrams if needed
 
 ---
 
@@ -131,3 +152,12 @@ For each item:
 - Be specific: reference actual file paths, function names, table names, and column names from the code
 - Do not invent content — if something cannot be determined from the provided code, say so explicitly
 - Output pure Markdown only — no prose outside of section content
+
+## Mermaid Diagram Rules (apply to all diagrams)
+
+- Always use `flowchart TB` — never `flowchart LR`
+- Maximum **12 nodes per diagram** — split into sub-diagrams if more are needed
+- Use short, human-readable node labels — no file extensions, no full paths
+- Use `subgraph` blocks to group related nodes visually
+- Keep arrow labels short (under 40 characters); omit if they add no information
+- Never nest subgraphs more than 2 levels deep

--- a/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
@@ -22,12 +22,14 @@ Append the new merge date and PR number as an additional row or line. Do not rem
 
 ### 3. Architecture Diagram (Mermaid)
 Add, remove, or relabel nodes and edges only if the new diff introduces or removes components or changes their dependencies. Preserve unchanged parts exactly.
+If the updated diagram would exceed 12 nodes, split into 3a (client-side) and 3b (backend/cloud) sub-diagrams.
 
 ### 4. Information Flow Diagram (Mermaid)
-Update arrows and labels only for data flows that changed or were added. Preserve unchanged flows.
+Maintain the split into write path (4a) and read path (4b). Update only the path affected by this PR. Reproduce unaffected paths unchanged.
 
 ### 5. Class Diagram (Mermaid)
 Add new classes, interfaces, or relationships introduced by the PR. Remove entries only if the PR explicitly deletes them. Preserve everything else.
+If the updated diagram would exceed 8 classes, split into 5a (data types) and 5b (components/modules).
 
 ### 6. Implementation Units
 Add new modules and components introduced by the PR. For modified modules, update only the fields and methods that changed. For deleted modules, remove their entries. Preserve unmodified entries exactly.
@@ -59,3 +61,12 @@ Return the complete updated specification as a single Markdown document. Do not 
 - Be specific: reference actual file paths, function names, table names, and column names from the code
 - Do not invent content — if something cannot be determined from the provided code, say so explicitly
 - Output pure Markdown only — no prose outside of section content
+
+## Mermaid Diagram Rules (apply to all diagrams)
+
+- Always use `flowchart TB` — never `flowchart LR`
+- Maximum **12 nodes per diagram** — split into sub-diagrams if more are needed
+- Use short, human-readable node labels — no file extensions, no full paths
+- Use `subgraph` blocks to group related nodes visually
+- Keep arrow labels short (under 40 characters); omit if they add no information
+- Never nest subgraphs more than 2 levels deep

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -41,14 +41,15 @@ async function main() {
   const existingSpecPath = process.env.EXISTING_SPEC_PATH || "";
   const isUpdate = existingSpecPath !== "" && await fileExists(existingSpecPath);
 
-  const [diff, sourceContext, promptTemplate, existingSpec] = await Promise.all([
+  const [diff, sourceContext, promptTemplate, existingSpec, linkedIssue] = await Promise.all([
     fs.readFile(diffPath, "utf8"),
     buildSourceContext(),
     fs.readFile(isUpdate ? UPDATE_PROMPT_PATH : CREATE_PROMPT_PATH, "utf8"),
     isUpdate ? fs.readFile(existingSpecPath, "utf8") : Promise.resolve(""),
+    fetchLinkedIssue(),
   ]);
 
-  const prompt = buildPrompt(promptTemplate, diff, sourceContext, existingSpec, isUpdate);
+  const prompt = buildPrompt(promptTemplate, diff, sourceContext, existingSpec, isUpdate, linkedIssue);
   process.stdout.write(`Calling Gemini (${isUpdate ? "update" : "create"} mode)...\n`);
 
   const specMarkdown = await callGemini(prompt);
@@ -62,7 +63,7 @@ async function main() {
 // Prompt assembly
 // ---------------------------------------------------------------------------
 
-function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate) {
+function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate, linkedIssue) {
   const metadata = {
     prNumber: process.env.PR_NUMBER || "",
     prTitle: process.env.PR_TITLE || "",
@@ -87,6 +88,27 @@ function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate) {
     "```json",
     JSON.stringify(metadata, null, 2),
     "```",
+  ];
+
+  if (linkedIssue) {
+    parts.push(
+      "",
+      "## Linked User Story Issue",
+      "",
+      `The PR body references issue #${linkedIssue.number}. Its content is below.`,
+      `Look for "Primary Owner:" and "Secondary Owner:" lines to populate Section 1.`,
+      "",
+      "```",
+      `Title: ${linkedIssue.title}`,
+      `Author: ${linkedIssue.author}`,
+      `Assignees: ${linkedIssue.assignees}`,
+      "",
+      linkedIssue.body,
+      "```",
+    );
+  }
+
+  parts.push(
     "",
     "## Unified Diff",
     "",
@@ -97,7 +119,7 @@ function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate) {
     "## Changed Source Files",
     "",
     sourceContext,
-  ];
+  );
 
   if (isUpdate && existingSpec) {
     parts.push(
@@ -109,6 +131,43 @@ function buildPrompt(template, diff, sourceContext, existingSpec, isUpdate) {
   }
 
   return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Linked issue fetching
+// ---------------------------------------------------------------------------
+
+async function fetchLinkedIssue() {
+  const prBody = process.env.PR_BODY || "";
+  const repoOwner = process.env.GITHUB_REPOSITORY || "";
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+
+  if (!token || !repoOwner) return null;
+
+  // Parse issue numbers from "Closes #N", "Fixes #N", "Relates to #N" patterns
+  const matches = [...prBody.matchAll(/(?:closes|fixes|relates\s+to)\s+#(\d+)/gi)];
+  if (matches.length === 0) return null;
+
+  const issueNumber = matches[0][1];
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repoOwner}/issues/${issueNumber}`,
+      { headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" } },
+    );
+    if (!response.ok) return null;
+
+    const issue = await response.json();
+    return {
+      number: issue.number,
+      title: issue.title || "",
+      author: issue.user?.login || "",
+      assignees: (issue.assignees || []).map((a) => a.login).join(", ") || "none",
+      body: issue.body || "",
+    };
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Mermaid layout rules**: all diagrams now use `flowchart TB`, max 12 nodes per diagram, split into sub-diagrams (3a/3b, 4a/4b, 5a/5b) when needed, short node labels, max 2 subgraph nesting levels
- **Owner extraction**: `generateDevSpec.mjs` now parses the PR body for `Closes #N` / `Fixes #N` patterns, fetches the linked issue via GitHub API, and includes its content in the prompt so Gemini can extract `Primary Owner` and `Secondary Owner` automatically
- **Workflow fix**: passes `GITHUB_REPOSITORY` env var to the script so the issue fetch works correctly

## How owner extraction works
1. Script reads `PR_BODY` env var
2. Finds first `Closes #N` / `Fixes #N` / `Relates to #N` reference
3. Fetches that issue via GitHub REST API
4. Injects issue title, author, assignees, and body into the prompt
5. Gemini reads `Primary Owner:` / `Secondary Owner:` lines from the issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)