### PR TITLE
fix(dev-spec): forbid special chars in Mermaid node labels to prevent parse errors

### DIFF
--- a/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
@@ -161,3 +161,4 @@ For each item:
 - Use `subgraph` blocks to group related nodes visually
 - Keep arrow labels short (under 40 characters); omit if they add no information
 - Never nest subgraphs more than 2 levels deep
+- **Never use parentheses `()`, brackets `[]`, braces `{}`, or angle brackets `<>` inside node label text** — these are Mermaid shape delimiters and will cause parse errors. Strip function call parens (e.g. use `upsertFavoriteNote` not `upsertFavoriteNote()`). If a label must contain special characters, wrap the entire label in double quotes: `nodeId["label with (parens)"]`

--- a/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
@@ -70,3 +70,4 @@ Return the complete updated specification as a single Markdown document. Do not 
 - Use `subgraph` blocks to group related nodes visually
 - Keep arrow labels short (under 40 characters); omit if they add no information
 - Never nest subgraphs more than 2 levels deep
+- **Never use parentheses `()`, brackets `[]`, braces `{}`, or angle brackets `<>` inside node label text** — these are Mermaid shape delimiters and will cause parse errors. Strip function call parens (e.g. use `upsertFavoriteNote` not `upsertFavoriteNote()`). If a label must contain special characters, wrap the entire label in double quotes: `nodeId["label with (parens)"]`


### PR DESCRIPTION
## Summary
Adds an explicit rule to both `DEV_SPEC_CREATE_PROMPT.md` and `DEV_SPEC_UPDATE_PROMPT.md` to prevent Mermaid parse errors caused by special characters in node labels.

## Problem
The generated dev spec contained node labels like `upsertFavoriteNote()` which caused a Mermaid parse error because `()` is interpreted as a stadium shape delimiter, not literal text.

## Fix
Added rule to the Mermaid Diagram Rules section in both prompt files:
- Strip function call parentheses from node labels
- Use `nodeId["label with (parens)"]` syntax if special characters are unavoidable

🤖 Generated with [Claude Code](https://claude.com/claude-code)