### PR TITLE
fix(dev-spec): comprehensive Mermaid validation and self-healing loop improvements

### DIFF
--- a/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
@@ -38,7 +38,7 @@ Produce a `flowchart TB` diagram grouped by execution layer using subgraphs:
 - If more than 12 components are involved, split into two diagrams:
   - **3a. Client-side architecture** — components and lib modules only
   - **3b. Backend and cloud architecture** — server, database, and cloud services only
-- Use short node labels (filename stem only, e.g. `restaurant-ingredient-items` not the full path)
+- Use **short descriptive aliases** for node IDs and labels — never file paths or route strings. E.g. use `edit_dish_screen` not `restaurant-edit-dish/[dishId].tsx`, use `dish_detail` not `dish/[dishId].tsx`. Node IDs must be alphanumeric with underscores only.
 - Always use `flowchart TB` — never `LR`
 - Prefer 2–3 levels of depth; avoid chains longer than 4 nodes
 

--- a/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
@@ -66,7 +66,7 @@ Return the complete updated specification as a single Markdown document. Do not 
 
 - Always use `flowchart TB` — never `flowchart LR`
 - Maximum **12 nodes per diagram** — split into sub-diagrams if more are needed
-- Use short, human-readable node labels — no file extensions, no full paths
+- Use **short descriptive aliases** for node IDs and labels — never file paths or route strings. E.g. use `edit_dish_screen` not `restaurant-edit-dish/[dishId].tsx`, use `dish_detail` not `dish/[dishId].tsx`. Node IDs must be alphanumeric with underscores only.
 - Use `subgraph` blocks to group related nodes visually
 - Keep arrow labels short (under 40 characters); omit if they add no information
 - Never nest subgraphs more than 2 levels deep

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -54,27 +54,38 @@ async function main() {
 
   let specMarkdown = await callGemini(prompt);
 
-  // Self-healing Mermaid validation loop — up to 3 fix attempts
-  const MAX_FIX_ATTEMPTS = 3;
+  // Self-healing Mermaid validation loop — runs until clean or MAX_FIX_ATTEMPTS reached.
+  // Each fix call receives the full history of prior errors so Gemini knows what it got wrong.
+  const MAX_FIX_ATTEMPTS = 20;
+  const errorHistory = []; // accumulated per-attempt error records
   for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
     const mermaidErrors = validateMermaidBlocks(specMarkdown);
-    if (mermaidErrors.length === 0) break;
+    if (mermaidErrors.length === 0) {
+      process.stdout.write(`Mermaid validation passed${attempt > 1 ? ` after ${attempt - 1} fix(es)` : ""}.\n`);
+      break;
+    }
 
     process.stdout.write(
-      `Mermaid validation attempt ${attempt}: found ${mermaidErrors.length} error(s). Asking Gemini to fix...\n`,
+      `Mermaid validation attempt ${attempt}/${MAX_FIX_ATTEMPTS}: found ${mermaidErrors.length} error(s). Asking Gemini to fix...\n`,
     );
     mermaidErrors.forEach(({ diagramIndex, errors }) => {
       process.stdout.write(`  Diagram ${diagramIndex + 1}: ${errors.join("; ")}\n`);
     });
 
-    specMarkdown = await fixMermaidErrors(specMarkdown, mermaidErrors);
+    // Record this attempt's errors in the history before calling fix
+    errorHistory.push({ attempt, mermaidErrors });
 
+    specMarkdown = await fixMermaidErrors(specMarkdown, mermaidErrors, errorHistory);
+
+    // After the last attempt, do a final validation check
     if (attempt === MAX_FIX_ATTEMPTS) {
       const remaining = validateMermaidBlocks(specMarkdown);
       if (remaining.length > 0) {
         process.stdout.write(
           `Warning: ${remaining.length} Mermaid error(s) remain after ${MAX_FIX_ATTEMPTS} fix attempts. Writing spec anyway.\n`,
         );
+      } else {
+        process.stdout.write(`Mermaid validation passed after ${MAX_FIX_ATTEMPTS} fix(es).\n`);
       }
     }
   }
@@ -488,9 +499,12 @@ function checkMermaidContent(content) {
 
 /**
  * Call Gemini with a targeted prompt to fix only the broken diagrams.
+ * @param {string} spec - full spec markdown
+ * @param {Array} mermaidErrors - current round's errors: [{ diagramIndex, content, errors[] }]
+ * @param {Array} errorHistory - all prior rounds: [{ attempt, mermaidErrors[] }]
  * Returns the spec with fixed diagrams substituted back in.
  */
-async function fixMermaidErrors(spec, mermaidErrors) {
+async function fixMermaidErrors(spec, mermaidErrors, errorHistory = []) {
   const blocks = extractMermaidBlocks(spec);
 
   // Build a prompt that shows only the broken diagrams + their errors
@@ -498,7 +512,7 @@ async function fixMermaidErrors(spec, mermaidErrors) {
     return [
       `### Diagram ${diagramIndex + 1}`,
       "",
-      "**Errors found:**",
+      "**Errors found in this attempt:**",
       errors.map((e) => `- ${e}`).join("\n"),
       "",
       "**Current (broken) Mermaid code:**",
@@ -508,21 +522,43 @@ async function fixMermaidErrors(spec, mermaidErrors) {
     ].join("\n");
   });
 
+  // Summarise errors from all prior attempts so Gemini sees what it got wrong before
+  const priorAttemptSummary = errorHistory.slice(0, -1); // exclude the current (last) attempt
+  const historySection = priorAttemptSummary.length > 0
+    ? [
+        "## Prior fix attempts (DO NOT repeat these mistakes)",
+        "",
+        ...priorAttemptSummary.map(({ attempt, mermaidErrors: prevErrors }) =>
+          [
+            `### Attempt ${attempt} errors`,
+            ...prevErrors.flatMap(({ diagramIndex, errors }) =>
+              errors.map((e) => `- Diagram ${diagramIndex + 1}: ${e}`),
+            ),
+          ].join("\n"),
+        ),
+        "",
+      ]
+    : [];
+
   const fixPrompt = [
     "You are fixing broken Mermaid diagrams in a development specification.",
     "Return ONLY the corrected Mermaid diagrams — one per section, in the same order as shown below.",
     "Do not add any prose, explanations, or extra text.",
     "",
-    "## Rules",
+    "## Rules (strictly enforce every rule — previous attempts violated them)",
     "- Always use `flowchart TB` — never `flowchart LR`",
     "- Node IDs must be alphanumeric with underscores only — NO hyphens, NO slashes, NO dots",
-    "- Never use `()`, `[]`, `{}`, `/`, or `<>` inside unquoted node label text — wrap the entire label in double quotes: `nodeId[\"my label\"]`",
-    "- Arrow pipe labels `-->|label|` must NOT contain `()`, `[]`, or `{}` — remove or simplify those characters from the label text",
+    "  WRONG: `dish-detail`, `app/config`, `dish.tsx`  RIGHT: `dish_detail`, `app_config`, `dish_tsx`",
+    "- NEVER put file paths or route strings in node IDs or labels. Use short descriptive aliases.",
+    "  WRONG: `dish_dishId_tsx[dish/[dishId].tsx]`  RIGHT: `dish_detail[dish detail]`",
+    "  WRONG: `restaurant-edit-dish/[dishId].tsx`    RIGHT: `edit_dish_screen`",
+    "- Never use `()`, `[]`, `{}`, `/`, or `<>` inside unquoted node label text — wrap in double quotes if needed",
+    "- Arrow pipe labels `-->|label|` must NOT contain `()`, `[]`, or `{}` — simplify or remove them",
     "- Always use `-->|label|` for labeled arrows — never `-- label -->`",
     "- Never use reserved keywords (`end`, `subgraph`, `style`, `classDef`) as bare node IDs",
-    "- In classDiagram, member return types must not contain `{` or `}` — write `map` or `object` instead of `{ok: boolean}`",
-    "- Wrap any label containing special characters in double quotes",
+    "- In classDiagram, member return types must not use `{` or `}` — write `map` or `object` instead",
     "",
+    ...historySection,
     "## Diagrams to fix",
     "",
     brokenSections.join("\n\n"),

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -56,7 +56,7 @@ async function main() {
 
   // Self-healing Mermaid validation loop — runs until clean or MAX_FIX_ATTEMPTS reached.
   // Each fix call receives the full history of prior errors so Gemini knows what it got wrong.
-  const MAX_FIX_ATTEMPTS = 20;
+  const MAX_FIX_ATTEMPTS = 10;
   const errorHistory = []; // accumulated per-attempt error records
   for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
     const mermaidErrors = validateMermaidBlocks(specMarkdown);

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -55,8 +55,9 @@ async function main() {
   let specMarkdown = await callGemini(prompt);
 
   // Self-healing Mermaid validation loop — runs until clean or MAX_FIX_ATTEMPTS reached.
-  // Each fix call receives the full history of prior errors so Gemini knows what it got wrong.
-  const MAX_FIX_ATTEMPTS = 10;
+  // Each fix call receives a truncated history of recent errors so Gemini knows what it got
+  // wrong without the prompt growing unboundedly across many attempts.
+  const MAX_FIX_ATTEMPTS = 5;
   const errorHistory = []; // accumulated per-attempt error records
   for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
     const mermaidErrors = validateMermaidBlocks(specMarkdown);
@@ -522,11 +523,15 @@ async function fixMermaidErrors(spec, mermaidErrors, errorHistory = []) {
     ].join("\n");
   });
 
-  // Summarise errors from all prior attempts so Gemini sees what it got wrong before
-  const priorAttemptSummary = errorHistory.slice(0, -1); // exclude the current (last) attempt
+  // Summarise errors from recent prior attempts so Gemini sees what it got wrong before.
+  // Cap at the last 3 attempts to keep the prompt from growing unboundedly.
+  const MAX_HISTORY_ENTRIES = 3;
+  const priorAttemptSummary = errorHistory
+    .slice(0, -1)                          // exclude the current (last) attempt
+    .slice(-MAX_HISTORY_ENTRIES);          // keep only the most recent N entries
   const historySection = priorAttemptSummary.length > 0
     ? [
-        "## Prior fix attempts (DO NOT repeat these mistakes)",
+        `## Prior fix attempts — last ${priorAttemptSummary.length} shown (DO NOT repeat these mistakes)`,
         "",
         ...priorAttemptSummary.map(({ attempt, mermaidErrors: prevErrors }) =>
           [


### PR DESCRIPTION
## Summary

- **5-attempt self-healing loop**: fix loop now runs up to 5 times (was 3) and stops as soon as all diagrams are clean
- **Error history in fix prompt**: each Gemini fix call receives the last 3 attempts' error logs (capped to prevent prompt bloat) so it knows what it got wrong and doesn't repeat mistakes
- **Concrete WRONG/RIGHT examples** in fix prompt for the most persistent patterns (file paths as node labels, hyphens/slashes in node IDs)
- **Prompt rule fix**: replaced bad \`restaurant-ingredient-items\` example (hyphenated) with explicit rule — use short descriptive aliases, never file paths or route strings
- **Broader node ID validation**: detects hyphens, dots, and slashes; added standalone node ID check (bare identifiers on their own line)
- **Expanded reserved keyword list**: 7 → 30+ keywords across flowchart, sequence, state, ER, class, and git diagram types

## Relates to

Follows PR #111 (initial validation loop)

## Test plan

- [ ] Trigger workflow for US9 (PR #84) and verify no Mermaid parse errors
- [ ] Trigger workflow for US10 (PR #87) and verify same
- [ ] Check workflow logs for "Mermaid validation passed after N fix(es)" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)