### PR TITLE
fix(dev-spec): add pre-sanitizer and explicit TypeScript array notation rule

### DIFF
--- a/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_CREATE_PROMPT.md
@@ -163,6 +163,7 @@ For each item:
 - Never nest subgraphs more than 2 levels deep
 - **Never use parentheses `()`, brackets `[]`, braces `{}`, slashes `/`, or angle brackets `<>` inside node label text** — these are Mermaid shape delimiters and will cause parse errors. If a label must contain any of these characters, wrap the entire label in double quotes: `nodeId["label with (parens)"]`
 - **Arrow pipe labels must also be free of `()`, `[]`, and `{}`** — `-->|upsertNote|` is valid, `-->|upsertNote(id)|` is not. Strip all parens/brackets from arrow labels.
+- **Never use TypeScript array notation `Type[]` in labels or arrow labels** — `[]` breaks the Mermaid parser. Write `Type list` instead: `-->|DinerFavoriteListItem list|` not `-->|DinerFavoriteListItem[]|`
 - **Never use hyphens, dots, or slashes in node IDs** — these conflict with arrow syntax and cause parse errors. Use underscores instead: `dish_dishId_tsx` not `dish-[dishId].tsx`. Node IDs must be alphanumeric with underscores only.
 - **Always use `-->|label|` syntax for labeled arrows**, never `-- label -->` — the latter causes parse errors
 - **In `classDiagram`, member return types must not contain `{` or `}`** — write `map` or `object` instead of `{ok: boolean}`

--- a/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
+++ b/ai-workflows/DEV_SPEC_UPDATE_PROMPT.md
@@ -72,6 +72,7 @@ Return the complete updated specification as a single Markdown document. Do not 
 - Never nest subgraphs more than 2 levels deep
 - **Never use parentheses `()`, brackets `[]`, braces `{}`, slashes `/`, or angle brackets `<>` inside node label text** — these are Mermaid shape delimiters and will cause parse errors. If a label must contain any of these characters, wrap the entire label in double quotes: `nodeId["label with (parens)"]`
 - **Arrow pipe labels must also be free of `()`, `[]`, and `{}`** — `-->|upsertNote|` is valid, `-->|upsertNote(id)|` is not. Strip all parens/brackets from arrow labels.
+- **Never use TypeScript array notation `Type[]` in labels or arrow labels** — `[]` breaks the Mermaid parser. Write `Type list` instead: `-->|DinerFavoriteListItem list|` not `-->|DinerFavoriteListItem[]|`
 - **Never use hyphens, dots, or slashes in node IDs** — these conflict with arrow syntax and cause parse errors. Use underscores instead: `dish_dishId_tsx` not `dish-[dishId].tsx`. Node IDs must be alphanumeric with underscores only.
 - **Always use `-->|label|` syntax for labeled arrows**, never `-- label -->` — the latter causes parse errors
 - **In `classDiagram`, member return types must not contain `{` or `}`** — write `map` or `object` instead of `{ok: boolean}`

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -276,21 +276,24 @@ function preSanitizeMermaid(spec) {
     let fixed = body;
 
     // 1. TypeScript array notation in arrow pipe labels: -->|Type[]| → -->|Type list|
-    //    Matches any [...] that looks like a type annotation (starts with uppercase or
-    //    contains word chars) inside a pipe label.
-    fixed = fixed.replace(
-      /(\|[^|]*?)([A-Za-z_]\w*)\[\]([^|]*?\|)/g,
-      (m, pre, typeName, post) => `${pre}${typeName} list${post}`,
-    );
+    //    Two-stage: capture full pipe label, then replace ALL Type[] inside it.
+    //    e.g. -->|TypeA[], TypeB[]| → -->|TypeA list, TypeB list|
+    fixed = fixed.replace(/\|([^|]+)\|/g, (_m, label) => {
+      const fixedLabel = label.replace(/([A-Za-z_]\w*)\[\]/g, "$1 list");
+      return `|${fixedLabel}|`;
+    });
 
-    // 2. TypeScript array notation in unquoted square-bracket node labels:
-    //    nodeId[Type[]] → nodeId["Type list"]
-    //    nodeId[foo Type[] bar] → nodeId["foo Type list bar"]
-    fixed = fixed.replace(
-      /(\w+)\[([^\]"]*?)([A-Za-z_]\w*)\[\]([^\]"]*?)\]/g,
-      (m, nodeId, pre, typeName, post) =>
-        `${nodeId}["${(pre + typeName + " list" + post).trim()}"]`,
-    );
+    // 2. TypeScript array notation in unquoted square-bracket node labels.
+    //    Two-stage: capture the full unquoted label, then replace ALL Type[] inside it.
+    //    The inner pattern (?:[^\]"[]|\[\])* excludes [ from the filler chars so that
+    //    [] pairs are only consumed by the explicit \[\] branch, preventing the [ in a
+    //    Type[] from being greedily eaten before the pair can be matched as a unit.
+    //    e.g. nodeId[TypeA[], TypeB[]] → nodeId["TypeA list, TypeB list"]
+    fixed = fixed.replace(/(\w+)\[((?:[^\]"[]|\[\])*)\]/g, (match, nodeId, label) => {
+      if (!/[A-Za-z_]\w*\[\]/.test(label)) return match;
+      const newLabel = label.replace(/([A-Za-z_]\w*)\[\]/g, "$1 list");
+      return `${nodeId}["${newLabel.trim()}"]`;
+    });
 
     // 3. Hyphens in node IDs that appear before shape delimiters or arrows.
     //    e.g. my-node[label] → my_node[label], my-node --> → my_node -->

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -285,11 +285,13 @@ function preSanitizeMermaid(spec) {
 
     // 2. TypeScript array notation in unquoted square-bracket node labels.
     //    Two-stage: capture the full unquoted label, then replace ALL Type[] inside it.
-    //    The inner pattern (?:[^\]"[]|\[\])* excludes [ from the filler chars so that
-    //    [] pairs are only consumed by the explicit \[\] branch, preventing the [ in a
-    //    Type[] from being greedily eaten before the pair can be matched as a unit.
-    //    e.g. nodeId[TypeA[], TypeB[]] → nodeId["TypeA list, TypeB list"]
-    fixed = fixed.replace(/(\w+)\[((?:[^\]"[]|\[\])*)\]/g, (match, nodeId, label) => {
+    //    The inner pattern (?:[^\]"[]|\[[^\]]*\])* excludes [ from the filler chars so
+    //    that bracket pairs are only consumed by the explicit \[[^\]]*\] branch — this
+    //    handles both empty []  pairs (Type[]) and non-empty pairs (e.g. [nested]) inside
+    //    the outer label without the engine prematurely closing on an inner ].
+    //    e.g. nodeId[TypeA[], TypeB[]]                    → nodeId["TypeA list, TypeB list"]
+    //    e.g. nodeId[Label with [nested] text and Type[]] → nodeId["Label with [nested] text and Type list"]
+    fixed = fixed.replace(/(\w+)\[((?:[^\]"[]|\[[^\]]*\])*)\]/g, (match, nodeId, label) => {
       if (!/[A-Za-z_]\w*\[\]/.test(label)) return match;
       const newLabel = label.replace(/([A-Za-z_]\w*)\[\]/g, "$1 list");
       return `${nodeId}["${newLabel.trim()}"]`;

--- a/scripts/generateDevSpec.mjs
+++ b/scripts/generateDevSpec.mjs
@@ -54,6 +54,10 @@ async function main() {
 
   let specMarkdown = await callGemini(prompt);
 
+  // Pre-sanitize pass: automatically fix deterministic patterns that Gemini
+  // consistently gets wrong before entering the validation loop.
+  specMarkdown = preSanitizeMermaid(specMarkdown);
+
   // Self-healing Mermaid validation loop — runs until clean or MAX_FIX_ATTEMPTS reached.
   // Each fix call receives a truncated history of recent errors so Gemini knows what it got
   // wrong without the prompt growing unboundedly across many attempts.
@@ -255,6 +259,52 @@ async function fileExists(filePath) {
   } catch {
     return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid pre-sanitizer — deterministic fixes applied before validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Automatically repair common recurring Mermaid errors that Gemini reliably
+ * produces, so the validation loop starts from a cleaner baseline.
+ *
+ * Operates only inside ```mermaid ... ``` blocks. Does not touch prose sections.
+ */
+function preSanitizeMermaid(spec) {
+  return spec.replace(/```mermaid\s*\n([\s\S]*?)```/g, (fullMatch, body) => {
+    let fixed = body;
+
+    // 1. TypeScript array notation in arrow pipe labels: -->|Type[]| → -->|Type list|
+    //    Matches any [...] that looks like a type annotation (starts with uppercase or
+    //    contains word chars) inside a pipe label.
+    fixed = fixed.replace(
+      /(\|[^|]*?)([A-Za-z_]\w*)\[\]([^|]*?\|)/g,
+      (m, pre, typeName, post) => `${pre}${typeName} list${post}`,
+    );
+
+    // 2. TypeScript array notation in unquoted square-bracket node labels:
+    //    nodeId[Type[]] → nodeId["Type list"]
+    //    nodeId[foo Type[] bar] → nodeId["foo Type list bar"]
+    fixed = fixed.replace(
+      /(\w+)\[([^\]"]*?)([A-Za-z_]\w*)\[\]([^\]"]*?)\]/g,
+      (m, nodeId, pre, typeName, post) =>
+        `${nodeId}["${(pre + typeName + " list" + post).trim()}"]`,
+    );
+
+    // 3. Hyphens in node IDs that appear before shape delimiters or arrows.
+    //    e.g. my-node[label] → my_node[label], my-node --> → my_node -->
+    //    Only replaces hyphens in the ID token, not inside quoted labels.
+    fixed = fixed.replace(
+      /\b([A-Za-z_][A-Za-z0-9_]*(?:-[A-Za-z0-9_]+)+)(\s*(?:-->|---|[\[({]))/g,
+      (m, nodeId, suffix) => `${nodeId.replace(/-/g, "_")}${suffix}`,
+    );
+
+    // 4. Old-style labeled arrows: -- label --> → -->|label|
+    fixed = fixed.replace(/--\s+([^-\n][^\n]*?)\s+-->/g, (_m, label) => `-->|${label.trim()}|`);
+
+    return `\`\`\`mermaid\n${fixed}\`\`\``;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -557,6 +607,9 @@ async function fixMermaidErrors(spec, mermaidErrors, errorHistory = []) {
     "- NEVER put file paths or route strings in node IDs or labels. Use short descriptive aliases.",
     "  WRONG: `dish_dishId_tsx[dish/[dishId].tsx]`  RIGHT: `dish_detail[dish detail]`",
     "  WRONG: `restaurant-edit-dish/[dishId].tsx`    RIGHT: `edit_dish_screen`",
+    "- NEVER use TypeScript array notation `Type[]` in node labels or arrow labels — the `[]` breaks the parser.",
+    "  WRONG: `-->|DinerFavoriteListItem[] with note|`  RIGHT: `-->|DinerFavoriteListItem list with note|`",
+    "  WRONG: `lib[IngredientFormRow[]]`               RIGHT: `lib[IngredientFormRow list]` or `lib[\"IngredientFormRow list\"]`",
     "- Never use `()`, `[]`, `{}`, `/`, or `<>` inside unquoted node label text — wrap in double quotes if needed",
     "- Arrow pipe labels `-->|label|` must NOT contain `()`, `[]`, or `{}` — simplify or remove them",
     "- Always use `-->|label|` for labeled arrows — never `-- label -->`",


### PR DESCRIPTION
## Summary

- **Pre-sanitizer pass** (`preSanitizeMermaid`): deterministic regex fix applied immediately after initial generation, before the validation loop. Automatically corrects the most persistent patterns without needing an LLM call:
  - `Type[]` in arrow labels → `Type list` (e.g. `DinerFavoriteListItem[]` → `DinerFavoriteListItem list`)
  - `Type[]` in node labels → `"Type list"` (quoted)
  - Hyphenated node IDs before delimiters → underscored
  - Old-style `-- label -->` arrows → `-->|label|`
- **Explicit `Type[]` rule** added to both prompt files and the fix prompt with concrete WRONG/RIGHT examples

## Root cause

Gemini consistently generates TypeScript array notation (`Type[]`) in labels and arrow labels to express data types accurately. The validation loop catches it but Gemini regenerates the same pattern on every fix attempt. The pre-sanitizer handles this deterministically so it never reaches validation.

## Relates to

Follows PR #116

## Test plan

- [ ] Trigger workflow for US9 (PR #84) — verify no `Type[]` parse errors in generated spec
- [ ] Trigger workflow for US10 (PR #87) — same
- [ ] Check logs: "Mermaid validation passed" should appear with 0 or fewer fix iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)