### PR TITLE
fix(llm-review): handle invalid JSON escape sequences from gemini-2.5-pro

### DIFF
--- a/scripts/llmReview.mjs
+++ b/scripts/llmReview.mjs
@@ -240,8 +240,23 @@ async function parseModelResponse(response, provider) {
 
 function parseJsonResponse(rawResponse) {
   const fenced = rawResponse.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = fenced ? fenced[1] : rawResponse;
-  return JSON.parse(candidate);
+  const candidate = (fenced ? fenced[1] : rawResponse).trim();
+
+  // First attempt: parse as-is (works when the model returns clean JSON).
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    // gemini-2.5-pro sometimes emits invalid JSON escape sequences such as \w or \d
+    // (from regex patterns or Windows-style paths in the diff) even with
+    // responseMimeType:"application/json" set.
+    // Sanitize by escaping lone backslashes not part of a valid JSON escape sequence.
+    // Valid JSON escapes after \: " \ / b f n r t u{4hex}
+    const sanitized = candidate.replace(
+      /\\(?!["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,
+      "\\\\",
+    );
+    return JSON.parse(sanitized);
+  }
 }
 
 function normalizeReview(review) {


### PR DESCRIPTION
## Summary

- `gemini-2.5-pro` sometimes emits invalid JSON escape sequences (e.g. `\w`, `\d` from regex patterns in the diff, or `\p` from file paths) even with `responseMimeType: "application/json"` set
- This causes `JSON.parse` to throw `SyntaxError: Bad escaped character`
- Fix: try parsing as-is first; on failure, sanitize lone backslashes not part of a valid JSON escape sequence before re-attempting parse

## Root cause

The Gemini API's JSON mode enforces structure but not always perfectly valid escape sequences when the model reproduces content from the diff verbatim (e.g. regex literals, Windows paths).

## Test plan

- [ ] Trigger LLM review on a PR whose diff contains regex patterns (e.g. `/\w+/`) and verify the review completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)