### PR TITLE
Fix menu selection, list keys, and owner/diner flows

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from "expo-router";
 
 import { AuthDeepLinkHandler } from "@/components/AuthDeepLinkHandler";
 import { ActiveRoleProvider } from "@/contexts/ActiveRoleContext";
+import { DinerActiveMenuScanProvider } from "@/contexts/DinerActiveMenuScanContext";
 import { RoleSwitchToastProvider } from "@/contexts/RoleSwitchToastContext";
 
 const noSwipeOptions = { gestureEnabled: false, animation: 'none' as const };
@@ -9,6 +10,7 @@ const noSwipeOptions = { gestureEnabled: false, animation: 'none' as const };
 export default function RootLayout() {
   return (
     <ActiveRoleProvider>
+    <DinerActiveMenuScanProvider>
     <RoleSwitchToastProvider>
     <AuthDeepLinkHandler />
     <Stack screenOptions={{ headerShown: false }}>
@@ -38,6 +40,7 @@ export default function RootLayout() {
       <Stack.Screen name="restaurant-profile" options={noSwipeOptions} />
     </Stack>
     </RoleSwitchToastProvider>
+    </DinerActiveMenuScanProvider>
     </ActiveRoleProvider>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from "expo-router";
 import { AuthDeepLinkHandler } from "@/components/AuthDeepLinkHandler";
 import { ActiveRoleProvider } from "@/contexts/ActiveRoleContext";
 import { DinerActiveMenuScanProvider } from "@/contexts/DinerActiveMenuScanContext";
+import { RestaurantActiveMenuScanProvider } from "@/contexts/RestaurantActiveMenuScanContext";
 import { RoleSwitchToastProvider } from "@/contexts/RoleSwitchToastContext";
 
 const noSwipeOptions = { gestureEnabled: false, animation: 'none' as const };
@@ -11,6 +12,7 @@ export default function RootLayout() {
   return (
     <ActiveRoleProvider>
     <DinerActiveMenuScanProvider>
+    <RestaurantActiveMenuScanProvider>
     <RoleSwitchToastProvider>
     <AuthDeepLinkHandler />
     <Stack screenOptions={{ headerShown: false }}>
@@ -40,6 +42,7 @@ export default function RootLayout() {
       <Stack.Screen name="restaurant-profile" options={noSwipeOptions} />
     </Stack>
     </RoleSwitchToastProvider>
+    </RestaurantActiveMenuScanProvider>
     </DinerActiveMenuScanProvider>
     </ActiveRoleProvider>
   );

--- a/app/diner-favorites.tsx
+++ b/app/diner-favorites.tsx
@@ -463,7 +463,7 @@ export default function DinerFavoritesScreen() {
                   </Pressable>
                   {!collapsed &&
                     rows.map((row) => (
-                      <View key={row.dishId}>
+                      <View key={`${groupKey}:${row.dishId}`}>
                         <View style={styles.stackDivider} />
                         {renderDishRow(row)}
                       </View>

--- a/app/diner-home.tsx
+++ b/app/diner-home.tsx
@@ -29,6 +29,9 @@ import { MenuUploadError, uploadMenuImageFromUri } from '@/lib/upload-menu-image
 
 const MAX_BYTES = 20 * 1024 * 1024;
 
+/** Bound Home fetch so heavy users do not download unbounded scan rows (LLM review / perf). */
+const RECENT_SCANS_HOME_LIMIT = 100;
+
 /** Figma Diner Scan Menu */
 const FIG = {
   text: '#101828',
@@ -72,7 +75,7 @@ export default function DinerHomeScreen() {
   const loadRecentScans = useCallback(async () => {
     setScansLoading(true);
     try {
-      const rows = await fetchDinerRecentScans();
+      const rows = await fetchDinerRecentScans(RECENT_SCANS_HOME_LIMIT);
       setRecentScans(rows);
     } catch {
       setRecentScans([]);

--- a/app/diner-home.tsx
+++ b/app/diner-home.tsx
@@ -4,13 +4,24 @@ import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import { useCallback, useState } from 'react';
-import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 
 import { DinerTabScreenLayout } from '@/components/DinerTabScreenLayout';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { useDinerActiveMenuScan } from '@/contexts/DinerActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import { fetchDinerRecentScans, type DinerMenuScanListRow } from '@/lib/diner-menu-scans';
+import { dedupeRecentMenuScansPreferNewest } from '@/lib/diner-recent-menu-scans';
 import { formatScannedAtPast } from '@/lib/format-scan-time';
 import { writePendingMenuScan } from '@/lib/pending-menu-scan';
 import { supabase } from '@/lib/supabase';
@@ -37,9 +48,26 @@ function scanDisplayTitle(row: DinerMenuScanListRow): string {
 export default function DinerHomeScreen() {
   useGuardActiveRole('diner');
   const router = useRouter();
+  const { setActiveDinerMenuScan } = useDinerActiveMenuScan();
   const [busy, setBusy] = useState(false);
   const [scansLoading, setScansLoading] = useState(true);
   const [recentScans, setRecentScans] = useState<DinerMenuScanListRow[]>([]);
+  const [recentSearchQuery, setRecentSearchQuery] = useState('');
+
+  const dedupedRecentScans = useMemo(
+    () => dedupeRecentMenuScansPreferNewest(recentScans),
+    [recentScans]
+  );
+
+  const filteredRecentScans = useMemo(() => {
+    const q = recentSearchQuery.trim().toLowerCase();
+    if (!q) return dedupedRecentScans;
+    return dedupedRecentScans.filter((row) => {
+      const title = scanDisplayTitle(row).toLowerCase();
+      const rel = formatScannedAtPast(row.scanned_at).toLowerCase();
+      return title.includes(q) || rel.includes(q);
+    });
+  }, [dedupedRecentScans, recentSearchQuery]);
 
   const loadRecentScans = useCallback(async () => {
     setScansLoading(true);
@@ -157,12 +185,13 @@ export default function DinerHomeScreen() {
 
   const onOpenScan = useCallback(
     (scanId: string) => {
+      void setActiveDinerMenuScan(scanId);
       router.push({
         pathname: '/diner-menu',
         params: { scanId },
       });
     },
-    [router]
+    [router, setActiveDinerMenuScan]
   );
 
   const cardShadow = Platform.select({
@@ -267,30 +296,55 @@ export default function DinerHomeScreen() {
       ) : recentScans.length === 0 ? (
         <Text style={styles.emptyScans}>No scans yet — upload a menu to see it here.</Text>
       ) : (
-        recentScans.map((item) => (
-          <Pressable
-            key={item.id}
-            accessibilityRole="button"
-            onPress={() => onOpenScan(item.id)}
-            style={({ pressed }) => [styles.recentCard, { borderColor: FIG.borderCard }, cardShadow, pressed && styles.recentCardPressed]}
-          >
-            <LinearGradient
-              colors={['#FFEDD4', '#FFF7ED']}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={styles.recentIconGradient}
-            >
-              <MaterialCommunityIcons name="silverware-fork-knife" size={20} color={FIG.orangeStart} />
-            </LinearGradient>
-            <View style={styles.recentText}>
-              <Text style={styles.recentTitle} numberOfLines={1}>
-                {scanDisplayTitle(item)}
-              </Text>
-              <Text style={styles.recentSubtitle}>{formatScannedAtPast(item.scanned_at)}</Text>
-            </View>
-            <MaterialCommunityIcons name="chevron-right" size={20} color={FIG.chevron} />
-          </Pressable>
-        ))
+        <>
+          <View style={styles.recentSearchWrap}>
+            <MaterialCommunityIcons name="magnify" size={20} color={FIG.muted} style={styles.recentSearchIcon} />
+            <TextInput
+              value={recentSearchQuery}
+              onChangeText={setRecentSearchQuery}
+              placeholder="Search menus by name"
+              placeholderTextColor={FIG.muted}
+              style={styles.recentSearchInput}
+              autoCorrect={false}
+              autoCapitalize="none"
+              clearButtonMode="while-editing"
+              accessibilityLabel="Search recent scanned menus"
+            />
+          </View>
+          {filteredRecentScans.length === 0 ? (
+            <Text style={styles.emptyScans}>No menus match your search.</Text>
+          ) : (
+            filteredRecentScans.map((item) => (
+              <Pressable
+                key={item.id}
+                accessibilityRole="button"
+                onPress={() => onOpenScan(item.id)}
+                style={({ pressed }) => [
+                  styles.recentCard,
+                  { borderColor: FIG.borderCard },
+                  cardShadow,
+                  pressed && styles.recentCardPressed,
+                ]}
+              >
+                <LinearGradient
+                  colors={['#FFEDD4', '#FFF7ED']}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 1 }}
+                  style={styles.recentIconGradient}
+                >
+                  <MaterialCommunityIcons name="silverware-fork-knife" size={20} color={FIG.orangeStart} />
+                </LinearGradient>
+                <View style={styles.recentText}>
+                  <Text style={styles.recentTitle} numberOfLines={1}>
+                    {scanDisplayTitle(item)}
+                  </Text>
+                  <Text style={styles.recentSubtitle}>{formatScannedAtPast(item.scanned_at)}</Text>
+                </View>
+                <MaterialCommunityIcons name="chevron-right" size={20} color={FIG.chevron} />
+              </Pressable>
+            ))
+          )}
+        </>
       )}
     </DinerTabScreenLayout>
   );
@@ -377,6 +431,42 @@ const styles = StyleSheet.create({
     letterSpacing: -0.43,
     color: FIG.text,
     marginBottom: 12,
+  },
+  recentSearchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: FIG.borderCard,
+    paddingLeft: 14,
+    paddingRight: Platform.OS === 'ios' ? 12 : 10,
+    marginBottom: 12,
+    height: 48,
+    minHeight: 48,
+  },
+  recentSearchIcon: {
+    marginRight: 10,
+  },
+  recentSearchInput: {
+    flex: 1,
+    alignSelf: 'stretch',
+    fontSize: 16,
+    fontWeight: '400',
+    lineHeight: 20,
+    color: FIG.text,
+    paddingTop: Platform.OS === 'ios' ? 10 : 0,
+    paddingBottom: Platform.OS === 'ios' ? 14 : 0,
+    paddingRight: 6,
+    paddingLeft: 0,
+    margin: 0,
+    ...(Platform.OS === 'android'
+      ? {
+          textAlignVertical: 'center' as const,
+          includeFontPadding: false,
+          paddingVertical: 0,
+        }
+      : {}),
   },
   scansLoading: {
     paddingVertical: Spacing.xl,

--- a/app/diner-menu.tsx
+++ b/app/diner-menu.tsx
@@ -112,10 +112,18 @@ export default function DinerMenuScreen() {
       const prefSnap = await fetchDinerPreferences();
       const fetched = await fetchParsedMenuForScan(effectiveScanId);
       if (!fetched.ok) {
-        if (/not found/i.test(fetched.error)) {
+        const msg = fetched.error;
+        const isMissingScan = /^scan not found$/i.test(msg.trim());
+        if (isMissingScan) {
           await setActiveDinerMenuScan(null);
+          setPrefs(null);
+          setMenu(null);
+          setSelectedTags([]);
+          setError(null);
+          router.replace('/diner-menu');
+          return;
         }
-        throw new Error(fetched.error);
+        throw new Error(msg);
       }
 
       setPrefs(prefSnap);

--- a/app/diner-menu.tsx
+++ b/app/diner-menu.tsx
@@ -3,7 +3,7 @@ import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useFocusEffect } from '@react-navigation/native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -17,6 +17,7 @@ import {
 import { DinerTabScreenLayout } from '@/components/DinerTabScreenLayout';
 import { MenuFilterChip } from '@/components/MenuFilterChip';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { useDinerActiveMenuScan } from '@/contexts/DinerActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import type { DinerPreferenceSnapshot } from '@/lib/diner-preferences';
 import { fetchDinerPreferences, spiceDbToLabel } from '@/lib/diner-preferences';
@@ -48,6 +49,7 @@ const PRICE_SYMBOL: Record<string, string> = {
 export default function DinerMenuScreen() {
   useGuardActiveRole('diner');
   const router = useRouter();
+  const { setActiveDinerMenuScan } = useDinerActiveMenuScan();
   const params = useLocalSearchParams<{ scanId?: string | string[] }>();
   const scanIdRaw = params.scanId;
   const scanId = Array.isArray(scanIdRaw) ? scanIdRaw[0] : scanIdRaw;
@@ -58,6 +60,11 @@ export default function DinerMenuScreen() {
   const [error, setError] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [favoriteIds, setFavoriteIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const id = scanId?.trim();
+    if (id) void setActiveDinerMenuScan(id);
+  }, [scanId, setActiveDinerMenuScan]);
 
   useFocusEffect(
     useCallback(() => {
@@ -104,7 +111,12 @@ export default function DinerMenuScreen() {
 
       const prefSnap = await fetchDinerPreferences();
       const fetched = await fetchParsedMenuForScan(effectiveScanId);
-      if (!fetched.ok) throw new Error(fetched.error);
+      if (!fetched.ok) {
+        if (/not found/i.test(fetched.error)) {
+          await setActiveDinerMenuScan(null);
+        }
+        throw new Error(fetched.error);
+      }
 
       setPrefs(prefSnap);
       setMenu(fetched.menu);
@@ -113,7 +125,7 @@ export default function DinerMenuScreen() {
     } finally {
       setLoading(false);
     }
-  }, [scanId, router]);
+  }, [scanId, router, setActiveDinerMenuScan]);
 
   useFocusEffect(
     useCallback(() => {
@@ -153,6 +165,7 @@ export default function DinerMenuScreen() {
 
     return menu.sections
       .map((sec) => ({
+        id: sec.id,
         title: sec.title,
         items: sec.items.filter(matchesSelected),
       }))
@@ -357,8 +370,8 @@ export default function DinerMenuScreen() {
             <Text style={styles.filterEmptyText}>No dishes match all selected filters.</Text>
           ) : null}
 
-          {sectionBlocks.map((sec, idx) => (
-            <View key={`${sec.title}-${idx}`} style={styles.sectionBlock}>
+          {sectionBlocks.map((sec) => (
+            <View key={sec.id} style={styles.sectionBlock}>
               <Text style={styles.sectionHeading}>{sec.title}</Text>
               <View style={styles.cardList}>
                 {sec.items.map((dish) => (

--- a/app/restaurant-highlight.tsx
+++ b/app/restaurant-highlight.tsx
@@ -1,7 +1,7 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -69,6 +69,11 @@ export default function RestaurantHighlightScreen() {
       void load();
     }, [load]),
   );
+
+  useEffect(() => {
+    if (!hydrated) return;
+    void load();
+  }, [hydrated, load]);
 
   const onToggle = useCallback(
     async (dishId: string, key: 'is_featured' | 'is_new', value: boolean) => {

--- a/app/restaurant-highlight.tsx
+++ b/app/restaurant-highlight.tsx
@@ -1,5 +1,6 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
+import { useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
@@ -13,50 +14,47 @@ import {
 } from 'react-native';
 
 import { HighlightDishBadges } from '@/components/HighlightDishBadges';
-import { PrimaryButton } from '@/components/PrimaryButton';
 import { RestaurantTabScreenLayout } from '@/components/RestaurantTabScreenLayout';
 import { RestaurantUiInspect } from '@/constants/restaurant-ui-inspect';
 import { restaurantRoleTheme } from '@/constants/role-theme';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { useRestaurantActiveMenuScan } from '@/contexts/RestaurantActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import { fetchRestaurantMenuForScan, type RestaurantMenuDishRow } from '@/lib/restaurant-fetch-menu-for-scan';
+import { scanBelongsToOwnerRestaurant } from '@/lib/restaurant-menu-scans';
 import { touchRestaurantMenuScan, updateRestaurantDishHighlightFlags } from '@/lib/restaurant-menu-dishes';
-import { supabase } from '@/lib/supabase';
 
 const t = restaurantRoleTheme;
 
 export default function RestaurantHighlightScreen() {
   useGuardActiveRole('restaurant');
+  const router = useRouter();
+  const { activeScanId, hydrated, setActiveRestaurantMenuScan } = useRestaurantActiveMenuScan();
   const [loading, setLoading] = useState(true);
-  const [publishedScanId, setPublishedScanId] = useState<string | null>(null);
   const [dishes, setDishes] = useState<RestaurantMenuDishRow[]>([]);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const { data: userData } = await supabase.auth.getUser();
-      const user = userData?.user;
-      if (!user) {
-        setPublishedScanId(null);
+      if (!hydrated) {
         setDishes([]);
         return;
       }
-      const { data: restRow, error: restErr } = await supabase
-        .from('restaurants')
-        .select('published_menu_scan_id')
-        .eq('owner_id', user.id)
-        .maybeSingle();
-      if (restErr) throw restErr;
-      const scanId = restRow?.published_menu_scan_id ? String(restRow.published_menu_scan_id) : null;
-      setPublishedScanId(scanId);
-      if (!scanId) {
+      const sid = activeScanId?.trim();
+      if (!sid) {
         setDishes([]);
         return;
       }
-      const menu = await fetchRestaurantMenuForScan(scanId);
+      if (!(await scanBelongsToOwnerRestaurant(sid))) {
+        await setActiveRestaurantMenuScan(null);
+        setDishes([]);
+        return;
+      }
+      const menu = await fetchRestaurantMenuForScan(sid);
       if (menu.ok) {
         setDishes(menu.dishes);
       } else {
+        await setActiveRestaurantMenuScan(null);
         setDishes([]);
       }
     } catch {
@@ -64,7 +62,7 @@ export default function RestaurantHighlightScreen() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [activeScanId, hydrated, setActiveRestaurantMenuScan]);
 
   useFocusEffect(
     useCallback(() => {
@@ -74,7 +72,8 @@ export default function RestaurantHighlightScreen() {
 
   const onToggle = useCallback(
     async (dishId: string, key: 'is_featured' | 'is_new', value: boolean) => {
-      if (!publishedScanId) return;
+      const sid = activeScanId?.trim();
+      if (!sid) return;
       const prev = dishes.find((d) => d.id === dishId);
       if (!prev) return;
       setDishes((list) => list.map((d) => (d.id === dishId ? { ...d, [key]: value } : d)));
@@ -83,14 +82,15 @@ export default function RestaurantHighlightScreen() {
         setDishes((list) => list.map((d) => (d.id === dishId ? { ...d, [key]: prev[key] } : d)));
         return;
       }
-      await touchRestaurantMenuScan(publishedScanId);
+      await touchRestaurantMenuScan(sid);
     },
-    [dishes, publishedScanId],
+    [dishes, activeScanId],
   );
 
   const clearHighlight = useCallback(
     async (dishId: string) => {
-      if (!publishedScanId) return;
+      const sid = activeScanId?.trim();
+      if (!sid) return;
       const prev = dishes.find((d) => d.id === dishId);
       if (!prev) return;
       setDishes((list) =>
@@ -101,9 +101,9 @@ export default function RestaurantHighlightScreen() {
         setDishes((list) => list.map((d) => (d.id === dishId ? { ...d, ...prev } : d)));
         return;
       }
-      await touchRestaurantMenuScan(publishedScanId);
+      await touchRestaurantMenuScan(sid);
     },
-    [dishes, publishedScanId],
+    [dishes, activeScanId],
   );
 
   const highlighted = dishes.filter((d) => d.is_featured || d.is_new);
@@ -115,15 +115,24 @@ export default function RestaurantHighlightScreen() {
       <Text style={styles.title}>Highlight dishes</Text>
       <Text style={styles.subtitle}>Boost visibility and increase orders — mark items as Featured or New.</Text>
 
-      {loading ? (
+      {loading || !hydrated ? (
         <View style={styles.centerBlock}>
           <ActivityIndicator color={t.primary} />
         </View>
-      ) : !publishedScanId ? (
+      ) : !activeScanId?.trim() ? (
         <View style={styles.emptyRoot}>
           <MaterialCommunityIcons name="star-outline" size={40} color={Colors.textSecondary} />
-          <Text style={styles.emptyTitle}>Publish a menu first</Text>
-          <Text style={styles.emptySubtitle}>Once your menu is live, you can highlight dishes for diners.</Text>
+          <Text style={styles.emptyTitle}>Select a menu</Text>
+          <Text style={styles.emptySubtitle}>
+            Go to Home and choose a menu under Recent uploads to highlight dishes from that menu.
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push('/restaurant-home')}
+            style={({ pressed }) => [styles.goHomeBtn, pressed && { opacity: 0.88 }]}
+          >
+            <Text style={styles.goHomeBtnText}>Go to Home</Text>
+          </Pressable>
         </View>
       ) : (
         <ScrollView contentContainerStyle={styles.scroll} showsVerticalScrollIndicator={false}>
@@ -156,7 +165,7 @@ export default function RestaurantHighlightScreen() {
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>All menu items</Text>
-            <Text style={styles.hint}>Toggle Featured and New for any dish on your published menu.</Text>
+            <Text style={styles.hint}>Toggle Featured and New for any dish on the menu you selected on Home.</Text>
             {dishes.map((d) => (
               <View key={d.id} style={styles.rowCard}>
                 {d.image_url ? (
@@ -237,6 +246,18 @@ const styles = StyleSheet.create({
     ...Typography.body,
     color: Colors.textSecondary,
     textAlign: 'center',
+  },
+  goHomeBtn: {
+    marginTop: Spacing.md,
+    paddingHorizontal: 22,
+    paddingVertical: 12,
+    borderRadius: 16,
+    backgroundColor: t.primary,
+  },
+  goHomeBtnText: {
+    ...Typography.captionMedium,
+    fontWeight: '700',
+    color: Colors.white,
   },
   scroll: {
     paddingBottom: 120,

--- a/app/restaurant-home.tsx
+++ b/app/restaurant-home.tsx
@@ -3,12 +3,22 @@ import { useFocusEffect } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
-import { useCallback, useState } from 'react';
-import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 
 import { RestaurantTabScreenLayout } from '@/components/RestaurantTabScreenLayout';
 import { restaurantRoleTheme } from '@/constants/role-theme';
 import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
+import { useRestaurantActiveMenuScan } from '@/contexts/RestaurantActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import { fetchRestaurantRecentUploads, type RestaurantMenuScanListRow } from '@/lib/restaurant-menu-scans';
 import { formatScannedAtPast } from '@/lib/format-scan-time';
@@ -21,17 +31,31 @@ const t = restaurantRoleTheme;
 const MAX_BYTES = 20 * 1024 * 1024;
 
 /** Restaurant Upload Menu (images-only). */
+const RECENT_UPLOADS_LIMIT = 50;
+
 export default function RestaurantHomeScreen() {
   useGuardActiveRole('restaurant');
   const router = useRouter();
+  const { setActiveRestaurantMenuScan } = useRestaurantActiveMenuScan();
   const [busy, setBusy] = useState(false);
   const [scansLoading, setScansLoading] = useState(true);
   const [recentScans, setRecentScans] = useState<RestaurantMenuScanListRow[]>([]);
+  const [recentSearchQuery, setRecentSearchQuery] = useState('');
+
+  const filteredRecentUploads = useMemo(() => {
+    const q = recentSearchQuery.trim().toLowerCase();
+    if (!q) return recentScans;
+    return recentScans.filter((row) => {
+      const title = (row.restaurant_name?.trim() || 'Menu').toLowerCase();
+      const rel = formatScannedAtPast(row.last_activity_at).toLowerCase();
+      return title.includes(q) || rel.includes(q);
+    });
+  }, [recentScans, recentSearchQuery]);
 
   const loadRecent = useCallback(async () => {
     setScansLoading(true);
     try {
-      const rows = await fetchRestaurantRecentUploads(10);
+      const rows = await fetchRestaurantRecentUploads(RECENT_UPLOADS_LIMIT);
       setRecentScans(rows);
     } catch {
       setRecentScans([]);
@@ -130,6 +154,14 @@ export default function RestaurantHomeScreen() {
       }
     },
     [busy, resolveFileSize, router],
+  );
+
+  const onSelectMenuForOwnerTabs = useCallback(
+    (scanId: string) => {
+      void setActiveRestaurantMenuScan(scanId);
+      router.push('/restaurant-menu');
+    },
+    [router, setActiveRestaurantMenuScan]
   );
 
   const createBlank = useCallback(async () => {
@@ -239,11 +271,29 @@ export default function RestaurantHomeScreen() {
       ) : recentScans.length === 0 ? (
         <Text style={styles.emptyText}>No uploads yet — upload a menu to see it here.</Text>
       ) : (
-        recentScans.map((item) => (
+        <>
+          <View style={styles.recentSearchWrap}>
+            <MaterialCommunityIcons name="magnify" size={20} color={Colors.textSecondary} style={styles.recentSearchIcon} />
+            <TextInput
+              value={recentSearchQuery}
+              onChangeText={setRecentSearchQuery}
+              placeholder="Search uploads by name"
+              placeholderTextColor={Colors.textSecondary}
+              style={styles.recentSearchInput}
+              autoCorrect={false}
+              autoCapitalize="none"
+              clearButtonMode="while-editing"
+              accessibilityLabel="Search recent menu uploads"
+            />
+          </View>
+          {filteredRecentUploads.length === 0 ? (
+            <Text style={styles.emptyText}>No uploads match your search.</Text>
+          ) : (
+            filteredRecentUploads.map((item) => (
           <Pressable
             key={item.id}
             accessibilityRole="button"
-            onPress={() => router.push({ pathname: '/restaurant-review-menu', params: { scanId: item.id } })}
+            onPress={() => onSelectMenuForOwnerTabs(item.id)}
             style={({ pressed }) => [
               styles.recentCard,
               { borderColor: t.cardAccentBorder },
@@ -261,7 +311,9 @@ export default function RestaurantHomeScreen() {
             </View>
             <MaterialCommunityIcons name="chevron-right" size={24} color={Colors.textSecondary} />
           </Pressable>
-        ))
+            ))
+          )}
+        </>
       )}
     </RestaurantTabScreenLayout>
   );
@@ -327,6 +379,38 @@ const styles = StyleSheet.create({
     ...Typography.headingSmall,
     color: Colors.text,
     marginBottom: Spacing.base,
+  },
+  recentSearchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.white,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+    borderRadius: BorderRadius.lg,
+    paddingLeft: 14,
+    paddingRight: Platform.OS === 'ios' ? 12 : 10,
+    marginBottom: Spacing.base,
+    height: 48,
+    minHeight: 48,
+  },
+  recentSearchIcon: {
+    marginRight: 10,
+  },
+  recentSearchInput: {
+    flex: 1,
+    fontSize: 16,
+    lineHeight: 20,
+    color: Colors.text,
+    paddingTop: Platform.OS === 'ios' ? 10 : 0,
+    paddingBottom: Platform.OS === 'ios' ? 14 : 0,
+    margin: 0,
+    ...(Platform.OS === 'android'
+      ? {
+          textAlignVertical: 'center' as const,
+          includeFontPadding: false,
+          paddingVertical: 0,
+        }
+      : {}),
   },
   scansLoading: { paddingVertical: Spacing.xl, alignItems: 'center' },
   emptyText: { ...Typography.body, color: Colors.textSecondary, marginBottom: Spacing.base },

--- a/app/restaurant-menu.tsx
+++ b/app/restaurant-menu.tsx
@@ -9,11 +9,11 @@ import { ActivityIndicator, Alert, Image, Modal, Pressable, ScrollView, StyleShe
 import { HighlightDishBadges } from '@/components/HighlightDishBadges';
 import { restaurantRoleTheme } from '@/constants/role-theme';
 import { RestaurantTabScreenLayout } from '@/components/RestaurantTabScreenLayout';
-import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
+import { BorderRadius, Colors, Typography } from '@/constants/theme';
+import { useRestaurantActiveMenuScan } from '@/contexts/RestaurantActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
-import { formatScannedAtPast } from '@/lib/format-scan-time';
 import { buildPartnerMenuLink, buildPartnerMenuQrUrl, getOrCreateOwnerPartnerMenuToken } from '@/lib/partner-menu-access';
-import { fetchRestaurantAllUploads, type RestaurantMenuScanListRow } from '@/lib/restaurant-menu-scans';
+import { scanBelongsToOwnerRestaurant } from '@/lib/restaurant-menu-scans';
 import { supabase } from '@/lib/supabase';
 import { fetchRestaurantMenuForScan } from '@/lib/restaurant-fetch-menu-for-scan';
 
@@ -35,13 +35,9 @@ type DishRow = {
 export default function RestaurantMenuScreen() {
   useGuardActiveRole('restaurant');
   const router = useRouter();
-  // --- uploads list ---
-  const [uploadsLoading, setUploadsLoading] = useState(true);
-  const [allUploads, setAllUploads] = useState<RestaurantMenuScanListRow[]>([]);
-  const [publishedScanId, setPublishedScanId] = useState<string | null>(null);
+  const { activeScanId, hydrated, setActiveRestaurantMenuScan } = useRestaurantActiveMenuScan();
 
-  // --- selected menu detail ---
-  const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
+  const [publishedScanId, setPublishedScanId] = useState<string | null>(null);
   const [menuLoading, setMenuLoading] = useState(false);
   const [menuTitle, setMenuTitle] = useState<string>('My Menus');
   const [dishes, setDishes] = useState<DishRow[]>([]);
@@ -52,48 +48,42 @@ export default function RestaurantMenuScreen() {
   const [partnerLink, setPartnerLink] = useState<string | null>(null);
   const [partnerQrUrl, setPartnerQrUrl] = useState<string | null>(null);
 
-  // Load the owner's uploads + which scan is currently published.
-  const loadUploads = useCallback(async () => {
-    setUploadsLoading(true);
-    try {
-      const [uploads, { data: restRow }] = await Promise.all([
-        fetchRestaurantAllUploads(100),
-        supabase
-          .from('restaurants')
-          .select('published_menu_scan_id')
-          .eq(
-            'owner_id',
-            (await supabase.auth.getUser()).data?.user?.id ?? '',
-          )
-          .maybeSingle(),
-      ]);
-
-      const pubId = restRow?.published_menu_scan_id ? String(restRow.published_menu_scan_id) : null;
-      setAllUploads(uploads);
-      setPublishedScanId(pubId);
-
-      // Auto-select the published scan (or first upload) if nothing selected yet.
-      setSelectedScanId((prev) => {
-        if (prev && uploads.some((u) => u.id === prev)) return prev;
-        return pubId ?? uploads[0]?.id ?? null;
-      });
-    } catch {
-      // leave previous state on error
-    } finally {
-      setUploadsLoading(false);
-    }
-  }, []);
-
   useFocusEffect(
     useCallback(() => {
-      void loadUploads();
-    }, [loadUploads]),
+      let cancelled = false;
+      void (async () => {
+        try {
+          const {
+            data: { user },
+          } = await supabase.auth.getUser();
+          if (!user || cancelled) return;
+          const { data: restRow } = await supabase
+            .from('restaurants')
+            .select('published_menu_scan_id')
+            .eq('owner_id', user.id)
+            .maybeSingle();
+          if (cancelled) return;
+          const pubId = restRow?.published_menu_scan_id ? String(restRow.published_menu_scan_id) : null;
+          setPublishedScanId(pubId);
+
+          const aid = activeScanId?.trim();
+          if (aid && !(await scanBelongsToOwnerRestaurant(aid))) {
+            await setActiveRestaurantMenuScan(null);
+          }
+        } catch {
+          /* keep state */
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [activeScanId, setActiveRestaurantMenuScan]),
   );
 
-  // Load dishes for the selected scan.
   useEffect(() => {
     let cancelled = false;
-    if (!selectedScanId) {
+    const sid = activeScanId?.trim();
+    if (!sid) {
       setMenuTitle('My Menus');
       setDishes([]);
       return;
@@ -101,10 +91,11 @@ export default function RestaurantMenuScreen() {
     setMenuLoading(true);
     void (async () => {
       try {
-        const result = await fetchRestaurantMenuForScan(selectedScanId);
+        const result = await fetchRestaurantMenuForScan(sid);
         if (cancelled) return;
         if (!result.ok) {
-          setMenuTitle('Menu');
+          await setActiveRestaurantMenuScan(null);
+          setMenuTitle('My Menus');
           setDishes([]);
           return;
         }
@@ -130,7 +121,7 @@ export default function RestaurantMenuScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedScanId]);
+  }, [activeScanId, setActiveRestaurantMenuScan]);
 
   const formatDishPrice = (dish: DishRow): string | null => {
     if (dish.price_display?.trim()) return dish.price_display.trim();
@@ -192,12 +183,22 @@ export default function RestaurantMenuScreen() {
     }
   }, [downloadQrToCache]);
 
+  if (!hydrated) {
+    return (
+      <RestaurantTabScreenLayout activeTab="menu">
+        <View style={styles.centerBlock}>
+          <ActivityIndicator color={t.primary} />
+        </View>
+      </RestaurantTabScreenLayout>
+    );
+  }
+
   return (
     <RestaurantTabScreenLayout activeTab="menu">
       {/* Header */}
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle} numberOfLines={1}>
-          {selectedScanId ? menuTitle : 'My Menus'}
+          {activeScanId?.trim() ? menuTitle : 'My Menus'}
         </Text>
         <View style={styles.actionsRow}>
           <Pressable
@@ -224,142 +225,101 @@ export default function RestaurantMenuScreen() {
         </View>
       </View>
 
-      {uploadsLoading ? (
-        <View style={styles.centerBlock}>
-          <ActivityIndicator color={t.primary} />
+      {!activeScanId?.trim() ? (
+        <View style={styles.selectMenuEmpty}>
+          <MaterialCommunityIcons name="format-list-bulleted-square" size={40} color={Colors.textSecondary} />
+          <Text style={styles.selectMenuTitle}>Select a menu</Text>
+          <Text style={styles.selectMenuSubtitle}>
+            Go to Home, then choose a menu under Recent uploads to view dishes and manage this menu here.
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push('/restaurant-home')}
+            style={({ pressed }) => [styles.selectMenuBtn, pressed && { opacity: 0.88 }]}
+          >
+            <Text style={styles.selectMenuBtnText}>Go to Home</Text>
+          </Pressable>
         </View>
       ) : (
         <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
-          {/* ── All uploaded menus list ── */}
-          <Text style={styles.sectionTitle}>All uploaded menus</Text>
+          <View style={styles.menuDetailHeader}>
+            <Text style={styles.sectionTitle}>{menuTitle}</Text>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() =>
+                router.push({
+                  pathname: '/restaurant-review-menu',
+                  params: { scanId: activeScanId?.trim() ?? '' },
+                })
+              }
+              style={({ pressed }) => [styles.editBtn, pressed && { opacity: 0.8 }]}
+            >
+              <MaterialCommunityIcons name="pencil-outline" size={14} color={t.primaryDark} />
+              <Text style={styles.editBtnText}>Edit</Text>
+            </Pressable>
+          </View>
 
-          {allUploads.length === 0 ? (
-            <View style={styles.emptyCard}>
-              <MaterialCommunityIcons name="tray-arrow-up" size={32} color={t.primary} style={{ marginBottom: 8 }} />
-              <Text style={styles.emptyTitle}>No menus yet</Text>
-              <Text style={styles.emptySubtitle}>Upload your first menu from the Home tab.</Text>
+          {activeScanId?.trim() === publishedScanId ? (
+            <View style={styles.liveBar}>
+              <MaterialCommunityIcons name="check-circle" size={14} color={t.primaryDark} />
+              <Text style={styles.liveBarText}>This menu is currently live for customers</Text>
               <Pressable
                 accessibilityRole="button"
-                onPress={() => router.push('/restaurant-home')}
-                style={({ pressed }) => [styles.uploadBtn, pressed && { opacity: 0.85 }]}
+                onPress={() => void openQrModal()}
+                disabled={qrBusy}
+                style={({ pressed }) => [styles.qrInlineBtn, pressed && { opacity: 0.85 }]}
               >
-                <Text style={styles.uploadBtnText}>Upload menu</Text>
+                <MaterialCommunityIcons name="qrcode" size={14} color={Colors.white} />
+                <Text style={styles.qrInlineBtnText}>QR Code</Text>
               </Pressable>
             </View>
+          ) : null}
+
+          {menuLoading ? (
+            <View style={[styles.centerBlock, { minHeight: 80 }]}>
+              <ActivityIndicator color={t.primary} />
+            </View>
+          ) : dishes.length === 0 ? (
+            <Text style={styles.emptySubtitle}>No dishes in this menu yet.</Text>
           ) : (
-            allUploads.map((scan) => {
-              const isSelected = scan.id === selectedScanId;
-              const isPublished = scan.id === publishedScanId;
+            dishes.map((dish) => {
+              const price = formatDishPrice(dish);
               return (
                 <Pressable
-                  key={scan.id}
+                  key={dish.id}
                   accessibilityRole="button"
-                  onPress={() => setSelectedScanId(scan.id)}
-                  style={({ pressed }) => [
-                    styles.scanCard,
-                    isSelected && styles.scanCardActive,
-                    pressed && { opacity: 0.88 },
-                  ]}
+                  onPress={() =>
+                    router.push({ pathname: '/restaurant-owner-dish/[dishId]', params: { dishId: dish.id } })
+                  }
+                  style={({ pressed }) => [styles.dishCard, pressed && { opacity: 0.88 }]}
                 >
-                  <View style={[styles.scanIcon, isSelected && { backgroundColor: Colors.white }]}>
-                    <MaterialCommunityIcons name="silverware-fork-knife" size={22} color={t.primaryDark} />
-                  </View>
-                  <View style={styles.scanTextCol}>
-                    <Text style={styles.scanName} numberOfLines={1}>
-                      {scan.restaurant_name?.trim() || 'Menu'}
-                    </Text>
-                    <Text style={styles.scanTime}>{formatScannedAtPast(scan.last_activity_at)}</Text>
-                  </View>
-                  {isPublished ? (
-                    <View style={styles.publishedBadge}>
-                      <Text style={styles.publishedBadgeText}>Live</Text>
+                  <View style={styles.dishRow}>
+                    {dish.image_url ? (
+                      <Image source={{ uri: dish.image_url }} style={styles.dishImage} accessibilityLabel={dish.name} />
+                    ) : (
+                      <View style={styles.dishImagePlaceholder}>
+                        <MaterialCommunityIcons name="silverware-fork-knife" size={20} color={Colors.textPlaceholder} />
+                      </View>
+                    )}
+                    <View style={styles.dishTextCol}>
+                      <View style={styles.dishNameRow}>
+                        <Text style={styles.dishName} numberOfLines={1}>
+                          {dish.name}
+                        </Text>
+                        {price ? <Text style={styles.dishPrice}>{price}</Text> : null}
+                      </View>
+                      {dish.description ? (
+                        <Text style={styles.dishDesc} numberOfLines={2}>
+                          {dish.description}
+                        </Text>
+                      ) : null}
+                      <HighlightDishBadges is_featured={dish.is_featured} is_new={dish.is_new} />
                     </View>
-                  ) : null}
-                  <MaterialCommunityIcons name="chevron-right" size={20} color={Colors.textSecondary} />
+                  </View>
                 </Pressable>
               );
             })
           )}
-
-          {/* ── Selected menu detail ── */}
-          {selectedScanId ? (
-            <>
-              <View style={styles.sectionDivider} />
-              <View style={styles.menuDetailHeader}>
-                <Text style={styles.sectionTitle}>{menuTitle}</Text>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={() => router.push({ pathname: '/restaurant-review-menu', params: { scanId: selectedScanId } })}
-                  style={({ pressed }) => [styles.editBtn, pressed && { opacity: 0.8 }]}
-                >
-                  <MaterialCommunityIcons name="pencil-outline" size={14} color={t.primaryDark} />
-                  <Text style={styles.editBtnText}>Edit</Text>
-                </Pressable>
-              </View>
-
-              {selectedScanId === publishedScanId ? (
-                <View style={styles.liveBar}>
-                  <MaterialCommunityIcons name="check-circle" size={14} color={t.primaryDark} />
-                  <Text style={styles.liveBarText}>This menu is currently live for customers</Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => void openQrModal()}
-                    disabled={qrBusy}
-                    style={({ pressed }) => [styles.qrInlineBtn, pressed && { opacity: 0.85 }]}
-                  >
-                    <MaterialCommunityIcons name="qrcode" size={14} color={Colors.white} />
-                    <Text style={styles.qrInlineBtnText}>QR Code</Text>
-                  </Pressable>
-                </View>
-              ) : null}
-
-              {menuLoading ? (
-                <View style={[styles.centerBlock, { minHeight: 80 }]}>
-                  <ActivityIndicator color={t.primary} />
-                </View>
-              ) : dishes.length === 0 ? (
-                <Text style={styles.emptySubtitle}>No dishes in this menu yet.</Text>
-              ) : (
-                dishes.map((dish) => {
-                  const price = formatDishPrice(dish);
-                  return (
-                    <Pressable
-                      key={dish.id}
-                      accessibilityRole="button"
-                      onPress={() =>
-                        router.push({ pathname: '/restaurant-owner-dish/[dishId]', params: { dishId: dish.id } })
-                      }
-                      style={({ pressed }) => [styles.dishCard, pressed && { opacity: 0.88 }]}
-                    >
-                      <View style={styles.dishRow}>
-                        {dish.image_url ? (
-                          <Image source={{ uri: dish.image_url }} style={styles.dishImage} accessibilityLabel={dish.name} />
-                        ) : (
-                          <View style={styles.dishImagePlaceholder}>
-                            <MaterialCommunityIcons name="silverware-fork-knife" size={20} color={Colors.textPlaceholder} />
-                          </View>
-                        )}
-                        <View style={styles.dishTextCol}>
-                          <View style={styles.dishNameRow}>
-                            <Text style={styles.dishName} numberOfLines={1}>
-                              {dish.name}
-                            </Text>
-                            {price ? <Text style={styles.dishPrice}>{price}</Text> : null}
-                          </View>
-                          {dish.description ? (
-                            <Text style={styles.dishDesc} numberOfLines={2}>
-                              {dish.description}
-                            </Text>
-                          ) : null}
-                          <HighlightDishBadges is_featured={dish.is_featured} is_new={dish.is_new} />
-                        </View>
-                      </View>
-                    </Pressable>
-                  );
-                })
-              )}
-            </>
-          ) : null}
         </ScrollView>
       )}
 
@@ -424,8 +384,38 @@ const styles = StyleSheet.create({
   centerBlock: { justifyContent: 'center', alignItems: 'center', paddingVertical: 40 },
   scrollContent: { paddingHorizontal: 16, paddingBottom: 120, gap: 10 },
 
+  selectMenuEmpty: {
+    alignItems: 'center',
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  selectMenuTitle: {
+    ...Typography.headingSmall,
+    fontWeight: '800',
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  selectMenuSubtitle: {
+    ...Typography.caption,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  selectMenuBtn: {
+    marginTop: 8,
+    paddingHorizontal: 22,
+    paddingVertical: 12,
+    borderRadius: BorderRadius.full,
+    backgroundColor: t.primary,
+  },
+  selectMenuBtnText: {
+    ...Typography.captionMedium,
+    fontWeight: '700',
+    color: Colors.white,
+  },
+
   sectionTitle: { ...Typography.headingSmall, fontSize: 15, fontWeight: '700', color: Colors.text, marginTop: 4 },
-  sectionDivider: { height: 1, backgroundColor: '#E5E7EB', marginVertical: 6 },
   menuDetailHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   editBtn: {
     flexDirection: 'row',
@@ -437,41 +427,6 @@ const styles = StyleSheet.create({
     backgroundColor: t.primaryLight,
   },
   editBtnText: { fontSize: 13, fontWeight: '600', color: t.primaryDark },
-
-  // Scan list cards (same style as home "Recent uploads")
-  scanCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: Colors.white,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    borderRadius: BorderRadius.lg,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.base,
-    gap: Spacing.base,
-  },
-  scanCardActive: {
-    borderColor: t.cardAccentBorder,
-    backgroundColor: t.primaryLight,
-  },
-  scanIcon: {
-    width: 48,
-    height: 48,
-    borderRadius: BorderRadius.full,
-    backgroundColor: t.primaryLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  scanTextCol: { flex: 1, minWidth: 0 },
-  scanName: { ...Typography.bodyMedium, color: Colors.text },
-  scanTime: { ...Typography.caption, color: Colors.textSecondary, marginTop: 2 },
-  publishedBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: BorderRadius.full,
-    backgroundColor: t.primary,
-  },
-  publishedBadgeText: { fontSize: 11, fontWeight: '700', color: Colors.white },
 
   // Live bar shown under menu detail when scan is published
   liveBar: {
@@ -519,27 +474,7 @@ const styles = StyleSheet.create({
   dishName: { ...Typography.bodyMedium, fontWeight: '800', color: Colors.text, flex: 1 },
   dishPrice: { ...Typography.bodyMedium, fontWeight: '700', color: Colors.textSecondary },
   dishDesc: { ...Typography.body, color: Colors.textSecondary, marginTop: 4, fontSize: 13 },
-  // Empty state
-  emptyCard: {
-    alignItems: 'center',
-    paddingVertical: 32,
-    paddingHorizontal: 24,
-    backgroundColor: Colors.white,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    borderRadius: BorderRadius.lg,
-    gap: 4,
-  },
-  emptyTitle: { ...Typography.bodyMedium, fontWeight: '700', color: Colors.text },
   emptySubtitle: { ...Typography.caption, color: Colors.textSecondary, textAlign: 'center' as const },
-  uploadBtn: {
-    marginTop: 8,
-    paddingHorizontal: 18,
-    paddingVertical: 10,
-    borderRadius: BorderRadius.full,
-    backgroundColor: t.primary,
-  },
-  uploadBtnText: { ...Typography.captionMedium, fontWeight: '700', color: Colors.white },
 
   // Modal
   modalBackdrop: {

--- a/app/restaurant-review-menu.tsx
+++ b/app/restaurant-review-menu.tsx
@@ -20,6 +20,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { restaurantRoleTheme } from '@/constants/role-theme';
 import { Colors, Typography } from '@/constants/theme';
+import { useRestaurantActiveMenuScan } from '@/contexts/RestaurantActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
 import { fetchRestaurantMenuForScan, type RestaurantMenuDishRow } from '@/lib/restaurant-fetch-menu-for-scan';
 import { publishRestaurantMenu } from '@/lib/restaurant-publish-menu';
@@ -85,6 +86,13 @@ export default function RestaurantReviewMenuScreen() {
 
   const scanIdRaw = params.scanId;
   const scanId = Array.isArray(scanIdRaw) ? scanIdRaw[0] : scanIdRaw;
+
+  const { setActiveRestaurantMenuScan } = useRestaurantActiveMenuScan();
+
+  useEffect(() => {
+    const id = scanId?.trim();
+    if (id) void setActiveRestaurantMenuScan(id);
+  }, [scanId, setActiveRestaurantMenuScan]);
 
   const [loading, setLoading] = useState(Boolean(scanId));
   const [error, setError] = useState<string | null>(null);

--- a/components/DinerBottomNav.tsx
+++ b/components/DinerBottomNav.tsx
@@ -3,7 +3,9 @@ import { useRouter } from 'expo-router';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useDinerActiveMenuScan } from '@/contexts/DinerActiveMenuScanContext';
 import { dinerRoleTheme } from '@/constants/role-theme';
+import { getStoredActiveDinerMenuScanId } from '@/lib/diner-active-menu-scan-storage';
 import { RestaurantUiInspect } from '@/constants/restaurant-ui-inspect';
 import { Colors, Spacing, Typography } from '@/constants/theme';
 
@@ -14,7 +16,7 @@ type DinerBottomNavProps = {
   variant?: 'light' | 'dark';
 };
 
-const TABS: Array<{
+const TABS: {
   key: DinerTab;
   label: string;
   icon: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
@@ -23,7 +25,7 @@ const TABS: Array<{
     | '/diner-menu'
     | '/diner-favorites'
     | '/diner-profile';
-}> = [
+}[] = [
   { key: 'home', label: 'Home', icon: 'home-outline', route: '/diner-home' },
   { key: 'menu', label: 'Menu', icon: 'format-list-bulleted-square', route: '/diner-menu' },
   { key: 'favorites', label: 'Favorites', icon: 'heart-outline', route: '/diner-favorites' },
@@ -33,6 +35,7 @@ const TABS: Array<{
 export function DinerBottomNav({ activeTab, variant = 'light' }: DinerBottomNavProps) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const { activeScanId, hydrated } = useDinerActiveMenuScan();
   const accent = variant === 'dark' ? RestaurantUiInspect.accent : dinerRoleTheme.primary;
   const inactiveColor = variant === 'dark' ? RestaurantUiInspect.muted : Colors.textSecondary;
   const barBg = variant === 'dark' ? RestaurantUiInspect.surfaceDark : Colors.white;
@@ -51,8 +54,22 @@ export function DinerBottomNav({ activeTab, variant = 'light' }: DinerBottomNavP
           tab.key === 'favorites' && isActive
             ? 'heart'
             : tab.icon;
+        const onPressTab = () => {
+          if (tab.key === 'menu') {
+            void (async () => {
+              const id = (hydrated ? activeScanId : await getStoredActiveDinerMenuScanId())?.trim();
+              if (id) {
+                router.replace({ pathname: '/diner-menu', params: { scanId: id } });
+              } else {
+                router.replace('/diner-menu');
+              }
+            })();
+            return;
+          }
+          router.replace(tab.route);
+        };
         return (
-          <Pressable key={tab.key} style={styles.tab} onPress={() => router.replace(tab.route)}>
+          <Pressable key={tab.key} style={styles.tab} onPress={onPressTab}>
             <MaterialCommunityIcons
               name={iconName}
               size={24}

--- a/contexts/DinerActiveMenuScanContext.tsx
+++ b/contexts/DinerActiveMenuScanContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import {
+  clearStoredActiveDinerMenuScanId,
+  getStoredActiveDinerMenuScanId,
+  setStoredActiveDinerMenuScanId,
+} from '@/lib/diner-active-menu-scan-storage';
+
+type DinerActiveMenuScanContextValue = {
+  /** Last menu the diner chose or opened; persisted for tab navigation. */
+  activeScanId: string | null;
+  /** True after the first AsyncStorage read completes. */
+  hydrated: boolean;
+  setActiveDinerMenuScan: (scanId: string | null) => Promise<void>;
+};
+
+const DinerActiveMenuScanContext = createContext<DinerActiveMenuScanContextValue | null>(null);
+
+export function DinerActiveMenuScanProvider({ children }: { children: ReactNode }) {
+  const [activeScanId, setActiveScanId] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const id = await getStoredActiveDinerMenuScanId();
+      if (!cancelled) {
+        setActiveScanId(id);
+        setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setActiveDinerMenuScan = useCallback(async (scanId: string | null) => {
+    if (!scanId?.trim()) {
+      setActiveScanId(null);
+      await clearStoredActiveDinerMenuScanId();
+      return;
+    }
+    const id = scanId.trim();
+    setActiveScanId(id);
+    await setStoredActiveDinerMenuScanId(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({ activeScanId, hydrated, setActiveDinerMenuScan }),
+    [activeScanId, hydrated, setActiveDinerMenuScan]
+  );
+
+  return <DinerActiveMenuScanContext.Provider value={value}>{children}</DinerActiveMenuScanContext.Provider>;
+}
+
+export function useDinerActiveMenuScan(): DinerActiveMenuScanContextValue {
+  const ctx = useContext(DinerActiveMenuScanContext);
+  if (!ctx) {
+    throw new Error('useDinerActiveMenuScan must be used within DinerActiveMenuScanProvider');
+  }
+  return ctx;
+}

--- a/contexts/RestaurantActiveMenuScanContext.tsx
+++ b/contexts/RestaurantActiveMenuScanContext.tsx
@@ -1,0 +1,70 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import {
+  clearStoredRestaurantActiveMenuScanId,
+  getStoredRestaurantActiveMenuScanId,
+  setStoredRestaurantActiveMenuScanId,
+} from '@/lib/restaurant-active-menu-scan-storage';
+
+type RestaurantActiveMenuScanContextValue = {
+  activeScanId: string | null;
+  hydrated: boolean;
+  setActiveRestaurantMenuScan: (scanId: string | null) => Promise<void>;
+};
+
+const RestaurantActiveMenuScanContext = createContext<RestaurantActiveMenuScanContextValue | null>(null);
+
+export function RestaurantActiveMenuScanProvider({ children }: { children: ReactNode }) {
+  const [activeScanId, setActiveScanId] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const id = await getStoredRestaurantActiveMenuScanId();
+      if (!cancelled) {
+        setActiveScanId(id);
+        setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setActiveRestaurantMenuScan = useCallback(async (scanId: string | null) => {
+    if (!scanId?.trim()) {
+      setActiveScanId(null);
+      await clearStoredRestaurantActiveMenuScanId();
+      return;
+    }
+    const id = scanId.trim();
+    setActiveScanId(id);
+    await setStoredRestaurantActiveMenuScanId(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({ activeScanId, hydrated, setActiveRestaurantMenuScan }),
+    [activeScanId, hydrated, setActiveRestaurantMenuScan]
+  );
+
+  return (
+    <RestaurantActiveMenuScanContext.Provider value={value}>{children}</RestaurantActiveMenuScanContext.Provider>
+  );
+}
+
+export function useRestaurantActiveMenuScan(): RestaurantActiveMenuScanContextValue {
+  const ctx = useContext(RestaurantActiveMenuScanContext);
+  if (!ctx) {
+    throw new Error('useRestaurantActiveMenuScan must be used within RestaurantActiveMenuScanProvider');
+  }
+  return ctx;
+}

--- a/docs/human-tests/us7-highlight-dishes.md
+++ b/docs/human-tests/us7-highlight-dishes.md
@@ -3,7 +3,7 @@
 
 **Story (summary):** As a restaurant owner, I want to mark dishes on my **published** menu as **Featured** and/or **New**; as a diner, I want to see those highlights when browsing the digital menu.
 
-**Build / PR reference (implementation):** Owner screen **`restaurant-highlight`** (restaurant bottom nav **Highlight**): toggles persist via `updateRestaurantDishHighlightFlags` on the **published** menu scan (`published_menu_scan_id`). Diner-facing UI uses **`HighlightDishBadges`** (“Featured” / “New”) and, on **`diner-menu`**, highlight-style **tag chips** when dish tags include `featured`, `new`, or `popular` (and parser alias “chef’s recommendation” → featured). **`diner-highlight`** lists highlighted dishes from the published menu for the restaurant that matches the diner’s **most recent scan name** (see prerequisites). Partner QR flow can copy owner flags into tags when opening **`partner-menu`** → **`diner-menu`**.
+**Build / PR reference (implementation):** Owner screen **`restaurant-highlight`** (restaurant bottom nav **Highlight**): toggles persist via `updateRestaurantDishHighlightFlags` on the owner’s **selected** menu scan (chosen on **Home → Recent uploads**; see `docs/restaurant-owner.md`). **`published_menu_scan_id`** still defines the live menu for diners / partner QR. Diner-facing UI uses **`HighlightDishBadges`** (“Featured” / “New”) and, on **`diner-menu`**, highlight-style **tag chips** when dish tags include `featured`, `new`, or `popular` (and parser alias “chef’s recommendation” → featured). **`diner-highlight`** lists highlighted dishes from the published menu for the restaurant that matches the diner’s **most recent scan name** (see prerequisites). Partner QR flow can copy owner flags into tags when opening **`partner-menu`** → **`diner-menu`**.
 
 ---
 
@@ -22,7 +22,7 @@ Full detail: repo root [`README.md`](../../README.md).
 ## Prerequisites (tester setup)
 
 1. **Environment:** Dev or shared build pointed at your team’s Supabase project (see **Environment setup** above).
-2. **Owner account:** Restaurant role, with a **published menu** (`published_menu_scan_id` set on your `restaurants` row—your team’s normal “go live” flow). The **Highlight** tab loads that published scan only; if nothing is published, the screen explains that highlights are unavailable until the menu is live.
+2. **Owner account:** Restaurant role, with at least one menu upload. On **Home → Recent uploads**, select a menu so **Highlight** has a scan to load (empty state until you pick one). For diner-visible highlights, you still need **`published_menu_scan_id`** aligned with what diners scan (see story above).
 3. **Diner account:** Signed in as a **diner**.
 4. **Data alignment for `diner-highlight`:** The diner must have at least one **recent menu scan** whose **restaurant name** (as stored on the scan) **exactly matches** (trimmed, case-insensitive) a restaurant row that has **`published_menu_scan_id`** and highlights on dishes. If names differ, the Highlight dishes screen may show **no highlights** even though the owner toggled flags—record that as a data/setup issue.
 5. **Optional — partner path:** If you test **partner QR / partner link**, use the flow your team documents (`diner-partner-qr-scan` → **`partner-menu`** resolves to **`diner-menu`** with a `scanId`).
@@ -33,9 +33,9 @@ Full detail: repo root [`README.md`](../../README.md).
 
 ### Part A — Restaurant owner: mark highlights
 
-1. Sign in as **restaurant** and open bottom nav **Highlight** (route **`/restaurant-highlight`**).
-2. If you see **no published menu**, stop Part A and note: menu must be published first; otherwise continue.
-3. Confirm the list shows dishes from the **published** scan. Pick **three** dishes to remember by name: leave one **plain**, set one to **Featured** only, one to **New** only (or both on one dish if you want to test dual badges).
+1. Sign in as **restaurant**. On **Home → Recent uploads**, tap a menu so **Highlight** has an active scan; then open bottom nav **Highlight** (route **`/restaurant-highlight`**).
+2. If **Highlight** tells you to select a menu on Home, do step 1 first; otherwise continue.
+3. Confirm the list shows dishes from the **selected** scan (same scan as **Menu** after selection). Pick **three** dishes to remember by name: leave one **plain**, set one to **Featured** only, one to **New** only (or both on one dish if you want to test dual badges).
 4. Use the **switches** to turn **Featured** / **New** on and off. Confirm toggles **stick** after leaving the screen and returning (pull to refresh if available).
 5. Confirm **badges** on the owner list match the switches (**Featured** gold-style pill, **New** blue-style pill) via `HighlightDishBadges`.
 6. If the UI offers **clear** / remove highlight for a dish, use it and confirm both flags clear and badges disappear.
@@ -55,7 +55,7 @@ Full detail: repo root [`README.md`](../../README.md).
 
 ### Stop conditions
 
-- Owner **Highlight** tab empty → publish a menu first.
+- Owner **Highlight** tab empty / “select a menu” → choose an upload on **Home → Recent uploads** first.
 - Diner **Highlight dishes** empty but owner set flags → check **restaurant name** on latest scan vs `restaurants.name` and published scan id.
 - **RLS / auth errors** → record message; likely wrong account or env.
 

--- a/docs/restaurant-owner.md
+++ b/docs/restaurant-owner.md
@@ -60,6 +60,12 @@ Migration: [`supabase/migrations/20260324123000_restaurant_owner.sql`](../supaba
 
 To add restaurant access to an existing diner account, log in and use **Profile → Add restaurant** (`/add-restaurant`), which inserts `user_roles` and venue data.
 
+## Owner Menu / Highlight tabs (current app behavior)
+
+- **Home → Recent uploads:** includes a search field; tapping an upload sets the persisted **active menu scan** and navigates to **Menu**, so **Menu** and **Highlight** both load that scan’s dishes.
+- **Menu** no longer lists every upload on the tab; if no menu is selected yet, **Menu** and **Highlight** show an empty state that directs owners to choose an upload on **Home**.
+- **Highlight** toggles Featured/New on the **selected** menu scan; what diners see as “live” still follows **`restaurants.published_menu_scan_id`** (and partner QR), which may differ from the menu you’re editing.
+
 ## Applying migrations
 
 Requires **`cuisines`** (from `20260324120000_diner_personalization.sql`) before this file. From repo root:

--- a/lib/diner-active-menu-scan-storage.ts
+++ b/lib/diner-active-menu-scan-storage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@pickmyplate/diner-active-menu-scan-v1';
+
+export async function getStoredActiveDinerMenuScanId(): Promise<string | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw?.trim()) return null;
+    return raw.trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function setStoredActiveDinerMenuScanId(scanId: string): Promise<void> {
+  const id = scanId?.trim();
+  if (!id) return;
+  await AsyncStorage.setItem(STORAGE_KEY, id);
+}
+
+export async function clearStoredActiveDinerMenuScanId(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}

--- a/lib/diner-menu-scans.ts
+++ b/lib/diner-menu-scans.ts
@@ -9,17 +9,23 @@ export type DinerMenuScanListRow = {
 /**
  * Recent scans for the signed-in diner, newest first (matches index diner_menu_scans_profile_scanned_at_idx).
  */
-export async function fetchDinerRecentScans(): Promise<DinerMenuScanListRow[]> {
+export async function fetchDinerRecentScans(limit?: number): Promise<DinerMenuScanListRow[]> {
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return [];
 
-  const { data, error } = await supabase
+  let q = supabase
     .from('diner_menu_scans')
     .select('id, restaurant_name, scanned_at')
     .eq('profile_id', user.id)
     .order('scanned_at', { ascending: false });
+
+  if (typeof limit === 'number' && limit > 0) {
+    q = q.limit(limit);
+  }
+
+  const { data, error } = await q;
 
   if (error) throw error;
   return (data ?? []) as DinerMenuScanListRow[];

--- a/lib/diner-recent-menu-scans.ts
+++ b/lib/diner-recent-menu-scans.ts
@@ -1,0 +1,23 @@
+import type { DinerMenuScanListRow } from '@/lib/diner-menu-scans';
+
+/**
+ * When the same restaurant name appears on multiple scans, keeps only the first row.
+ * Input must be ordered newest-first (as from `fetchDinerRecentScans`), so the kept row is the most recent.
+ * Scans with no restaurant name are never merged—each stays visible.
+ */
+export function dedupeRecentMenuScansPreferNewest(rows: DinerMenuScanListRow[]): DinerMenuScanListRow[] {
+  const seenRestaurantKeys = new Set<string>();
+  const out: DinerMenuScanListRow[] = [];
+
+  for (const row of rows) {
+    const normalized = row.restaurant_name?.trim().toLowerCase();
+    if (normalized && normalized.length > 0) {
+      const key = `restaurant:${normalized}`;
+      if (seenRestaurantKeys.has(key)) continue;
+      seenRestaurantKeys.add(key);
+    }
+    out.push(row);
+  }
+
+  return out;
+}

--- a/lib/fetch-diner-highlight-dishes.ts
+++ b/lib/fetch-diner-highlight-dishes.ts
@@ -25,7 +25,7 @@ export async function fetchDinerHighlightDishes(): Promise<{
   restaurantName: string | null;
   rows: DinerHighlightDishRow[];
 }> {
-  const recentScans = await fetchDinerRecentScans();
+  const recentScans = await fetchDinerRecentScans(50);
   const latestRestaurantName = recentScans[0]?.restaurant_name?.trim() ?? null;
   if (!latestRestaurantName) return { restaurantName: null, rows: [] };
 

--- a/lib/restaurant-active-menu-scan-storage.ts
+++ b/lib/restaurant-active-menu-scan-storage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@pickmyplate/restaurant-active-menu-scan-v1';
+
+export async function getStoredRestaurantActiveMenuScanId(): Promise<string | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw?.trim()) return null;
+    return raw.trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function setStoredRestaurantActiveMenuScanId(scanId: string): Promise<void> {
+  const id = scanId?.trim();
+  if (!id) return;
+  await AsyncStorage.setItem(STORAGE_KEY, id);
+}
+
+export async function clearStoredRestaurantActiveMenuScanId(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}

--- a/lib/restaurant-menu-scans.ts
+++ b/lib/restaurant-menu-scans.ts
@@ -43,3 +43,20 @@ export async function fetchRestaurantRecentUploads(limit = 10): Promise<Restaura
 export async function fetchRestaurantAllUploads(limit = 100): Promise<RestaurantMenuScanListRow[]> {
   return fetchRestaurantRecentUploads(limit);
 }
+
+/** True if this menu scan belongs to the signed-in owner's restaurant. */
+export async function scanBelongsToOwnerRestaurant(scanId: string): Promise<boolean> {
+  try {
+    const restaurantId = await fetchOwnerRestaurantId();
+    const { data, error } = await supabase
+      .from('restaurant_menu_scans')
+      .select('id')
+      .eq('restaurant_id', restaurantId)
+      .eq('id', scanId.trim())
+      .maybeSingle();
+    if (error) throw error;
+    return !!data;
+  } catch {
+    return false;
+  }
+}

--- a/tests/diner-active-menu-scan-storage.test.ts
+++ b/tests/diner-active-menu-scan-storage.test.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  clearStoredActiveDinerMenuScanId,
+  getStoredActiveDinerMenuScanId,
+  setStoredActiveDinerMenuScanId,
+} from '@/lib/diner-active-menu-scan-storage';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('diner-active-menu-scan-storage', () => {
+  it('returns null when nothing stored', async () => {
+    expect(await getStoredActiveDinerMenuScanId()).toBeNull();
+  });
+
+  it('round-trips a scan id', async () => {
+    await setStoredActiveDinerMenuScanId('  scan-abc  ');
+    expect(await getStoredActiveDinerMenuScanId()).toBe('scan-abc');
+  });
+
+  it('clears stored id', async () => {
+    await setStoredActiveDinerMenuScanId('scan-1');
+    await clearStoredActiveDinerMenuScanId();
+    expect(await getStoredActiveDinerMenuScanId()).toBeNull();
+  });
+
+  it('ignores empty set', async () => {
+    await setStoredActiveDinerMenuScanId('   ');
+    expect(await getStoredActiveDinerMenuScanId()).toBeNull();
+  });
+});

--- a/tests/diner-recent-menu-scans.test.ts
+++ b/tests/diner-recent-menu-scans.test.ts
@@ -1,0 +1,28 @@
+import { dedupeRecentMenuScansPreferNewest } from '@/lib/diner-recent-menu-scans';
+import type { DinerMenuScanListRow } from '@/lib/diner-menu-scans';
+
+describe('dedupeRecentMenuScansPreferNewest', () => {
+  it('keeps newest scan when duplicate restaurant names appear', () => {
+    const rows: DinerMenuScanListRow[] = [
+      { id: 'new', restaurant_name: 'Joe Pizza', scanned_at: '2026-04-16T12:00:00Z' },
+      { id: 'old', restaurant_name: 'Joe Pizza', scanned_at: '2026-04-10T12:00:00Z' },
+    ];
+    expect(dedupeRecentMenuScansPreferNewest(rows)).toEqual([rows[0]]);
+  });
+
+  it('does not dedupe unnamed scans', () => {
+    const rows: DinerMenuScanListRow[] = [
+      { id: 'a', restaurant_name: null, scanned_at: '2026-04-16T12:00:00Z' },
+      { id: 'b', restaurant_name: null, scanned_at: '2026-04-15T12:00:00Z' },
+    ];
+    expect(dedupeRecentMenuScansPreferNewest(rows)).toEqual(rows);
+  });
+
+  it('treats same restaurant name with different casing as duplicate', () => {
+    const rows: DinerMenuScanListRow[] = [
+      { id: '1', restaurant_name: 'Joe Pizza', scanned_at: '2026-04-16T12:00:00Z' },
+      { id: '2', restaurant_name: 'JOE PIZZA', scanned_at: '2026-04-14T12:00:00Z' },
+    ];
+    expect(dedupeRecentMenuScansPreferNewest(rows)).toEqual([rows[0]]);
+  });
+});

--- a/tests/restaurant-active-menu-scan-storage.test.ts
+++ b/tests/restaurant-active-menu-scan-storage.test.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  clearStoredRestaurantActiveMenuScanId,
+  getStoredRestaurantActiveMenuScanId,
+  setStoredRestaurantActiveMenuScanId,
+} from '@/lib/restaurant-active-menu-scan-storage';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('restaurant-active-menu-scan-storage', () => {
+  it('returns null when nothing stored', async () => {
+    expect(await getStoredRestaurantActiveMenuScanId()).toBeNull();
+  });
+
+  it('round-trips a scan id', async () => {
+    await setStoredRestaurantActiveMenuScanId('  scan-xyz  ');
+    expect(await getStoredRestaurantActiveMenuScanId()).toBe('scan-xyz');
+  });
+
+  it('clears stored id', async () => {
+    await setStoredRestaurantActiveMenuScanId('scan-1');
+    await clearStoredRestaurantActiveMenuScanId();
+    expect(await getStoredRestaurantActiveMenuScanId()).toBeNull();
+  });
+
+  it('ignores empty set', async () => {
+    await setStoredRestaurantActiveMenuScanId('   ');
+    expect(await getStoredRestaurantActiveMenuScanId()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/qianxuege/PickMyPlate2/issues/79

## What this fixes

- **Favorites / lists:** Uses stable identifiers for React keys (e.g. menu sections by section `id`, favorites rows keyed with group + `dishId`) so duplicate dish names cannot produce duplicate keys.
- **Diner — menu clutter / selection:** Recent menus are manageable from **Home** (search + dedupe by restaurant name keeping newest first). **Menu** tab no longer shows a heavy “choose menu” UI; persisted active scan drives the **Menu** tab via `DinerActiveMenuScanContext` + storage. **Favorites** lists all restaurants (per product direction after the issue).
- **Restaurant owner:** **Home → Recent uploads** search + tap sets **active menu**; **Menu** and **Highlight** use that scan; removed inline “all uploads” list from **Menu**; empty states point owners to **Home** until a menu is selected (`RestaurantActiveMenuScanContext` + storage). Docs updated in `docs/restaurant-owner.md` and `docs/human-tests/us7-highlight-dishes.md`.

## How to verify

- Diner: Home → search/select a recent scan → **Menu** shows that menu; hearts/favorites behave without key warnings.
- Owner: Home → pick an upload → **Menu** / **Highlight** match that menu; with nothing selected, both tabs prompt to choose on Home.

## Commits

- `b1cd0fb` — diner menu switching / home search / favorites keys  
- `ef46d53` — restaurant owner menu selection + highlight alignment  
- `1fa88c8` — documentation updates  