### PR TITLE
test: unit tests for US9 — Add ingredient details and origin for dishes

### DIFF
--- a/tests/restaurant-ingredient-items.test.ts
+++ b/tests/restaurant-ingredient-items.test.ts
@@ -9,6 +9,10 @@ import {
   parseIngredientItemsFromDb,
 } from '@/lib/restaurant-ingredient-items';
 
+// ---------------------------------------------------------------------------
+// US9 ingredient constants
+// ---------------------------------------------------------------------------
+
 describe('US9 ingredient constants', () => {
   it('fixes max origin length at 100', () => {
     expect(MAX_DISH_INGREDIENT_ORIGIN_LEN).toBe(100);
@@ -19,13 +23,25 @@ describe('US9 ingredient constants', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// newIngredientFormRowId
+// ---------------------------------------------------------------------------
+
 describe('newIngredientFormRowId', () => {
-  it('returns a non-empty id string', () => {
-    const id = newIngredientFormRowId();
-    expect(typeof id).toBe('string');
-    expect(id.length).toBeGreaterThan(0);
+  it('generates unique ids across repeated calls', () => {
+    const iterations = 50;
+    const ids = Array.from({ length: iterations }, () => newIngredientFormRowId());
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => {
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    });
   });
 });
+
+// ---------------------------------------------------------------------------
+// parseIngredientItemsFromDb
+// ---------------------------------------------------------------------------
 
 describe('parseIngredientItemsFromDb', () => {
   it('returns empty for non-array', () => {
@@ -72,6 +88,10 @@ describe('parseIngredientItemsFromDb', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// fallbackIngredientNamesFromDishName
+// ---------------------------------------------------------------------------
+
 describe('fallbackIngredientNamesFromDishName', () => {
   it('splits words for simple snacks', () => {
     expect(fallbackIngredientNamesFromDishName('Pop corn')).toEqual(['Pop', 'corn']);
@@ -81,6 +101,10 @@ describe('fallbackIngredientNamesFromDishName', () => {
     expect(fallbackIngredientNamesFromDishName('Fish and chips')).toEqual(['Fish', 'chips']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// dishDbToIngredientFormRows
+// ---------------------------------------------------------------------------
 
 describe('dishDbToIngredientFormRows', () => {
   it('prefers ingredient_items over legacy ingredients', () => {
@@ -110,6 +134,10 @@ describe('dishDbToIngredientFormRows', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// normalizeIngredientItemsForPersist
+// ---------------------------------------------------------------------------
+
 describe('normalizeIngredientItemsForPersist', () => {
   it('trims, drops fully blank rows, coerces empty origin to null', () => {
     const r = normalizeIngredientItemsForPersist([
@@ -132,13 +160,6 @@ describe('normalizeIngredientItemsForPersist', () => {
     if (!r.ok) expect(r.error).toMatch(/name/i);
   });
 
-  it('rejects origin longer than max', () => {
-    const r = normalizeIngredientItemsForPersist([
-      { name: 'x', origin: 'a'.repeat(MAX_DISH_INGREDIENT_ORIGIN_LEN + 1) },
-    ]);
-    expect(r.ok).toBe(false);
-  });
-
   it('accepts origin trimmed to exactly max length', () => {
     const origin = 'a'.repeat(MAX_DISH_INGREDIENT_ORIGIN_LEN);
     const r = normalizeIngredientItemsForPersist([{ name: 'spice', origin }]);
@@ -147,7 +168,22 @@ describe('normalizeIngredientItemsForPersist', () => {
       items: [{ name: 'spice', origin }],
     });
   });
+
+  it('rejects origin one character over max length (paired boundary)', () => {
+    const origin = 'a'.repeat(MAX_DISH_INGREDIENT_ORIGIN_LEN + 1);
+    const r = normalizeIngredientItemsForPersist([{ name: 'spice', origin }]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toContain('spice');
+      expect(r.error).toMatch(/at most/);
+      expect(r.error).toContain(String(MAX_DISH_INGREDIENT_ORIGIN_LEN));
+    }
+  });
 });
+
+// ---------------------------------------------------------------------------
+// ingredientNamesForLegacy
+// ---------------------------------------------------------------------------
 
 describe('ingredientNamesForLegacy', () => {
   it('maps names', () => {

--- a/tests/restaurant-ingredient-items.test.ts
+++ b/tests/restaurant-ingredient-items.test.ts
@@ -1,11 +1,31 @@
 import {
+  DISH_INGREDIENT_ORIGIN_NOT_SPECIFIED,
   dishDbToIngredientFormRows,
   fallbackIngredientNamesFromDishName,
   ingredientNamesForLegacy,
   MAX_DISH_INGREDIENT_ORIGIN_LEN,
+  newIngredientFormRowId,
   normalizeIngredientItemsForPersist,
   parseIngredientItemsFromDb,
 } from '@/lib/restaurant-ingredient-items';
+
+describe('US9 ingredient constants', () => {
+  it('fixes max origin length at 100', () => {
+    expect(MAX_DISH_INGREDIENT_ORIGIN_LEN).toBe(100);
+  });
+
+  it('defines diner-facing copy when origin is omitted', () => {
+    expect(DISH_INGREDIENT_ORIGIN_NOT_SPECIFIED).toBe('Origin not specified');
+  });
+});
+
+describe('newIngredientFormRowId', () => {
+  it('returns a non-empty id string', () => {
+    const id = newIngredientFormRowId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+});
 
 describe('parseIngredientItemsFromDb', () => {
   it('returns empty for non-array', () => {
@@ -117,6 +137,15 @@ describe('normalizeIngredientItemsForPersist', () => {
       { name: 'x', origin: 'a'.repeat(MAX_DISH_INGREDIENT_ORIGIN_LEN + 1) },
     ]);
     expect(r.ok).toBe(false);
+  });
+
+  it('accepts origin trimmed to exactly max length', () => {
+    const origin = 'a'.repeat(MAX_DISH_INGREDIENT_ORIGIN_LEN);
+    const r = normalizeIngredientItemsForPersist([{ name: 'spice', origin }]);
+    expect(r).toEqual({
+      ok: true,
+      items: [{ name: 'spice', origin }],
+    });
   });
 });
 


### PR DESCRIPTION
Closes #142

Relates to #76

Adds coverage for US9 ingredient constants (`DISH_INGREDIENT_ORIGIN_NOT_SPECIFIED`, max length boundary), and `newIngredientFormRowId`.

Made with [Cursor](https://cursor.com)