### PR TITLE
fix: reject invalid emails without proper domain (closes #153)

### DIFF
--- a/app/diner-registration.tsx
+++ b/app/diner-registration.tsx
@@ -7,6 +7,7 @@ import { BackButton, InputField, PrimaryButton, ScreenContainer } from '@/compon
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { isDuplicateEmailSignupError, linkDinerToExistingAccount } from '@/lib/link-account';
+import { isValidEmail } from '@/lib/is-valid-email';
 import { supabase } from '@/lib/supabase';
 
 export default function DinerRegistrationScreen() {
@@ -22,6 +23,10 @@ export default function DinerRegistrationScreen() {
     const trimmedEmail = email.trim();
     if (!name.trim() || !trimmedEmail || !password) {
       Alert.alert('Missing info', 'Please fill in name, email, and password.');
+      return;
+    }
+    if (!isValidEmail(trimmedEmail)) {
+      Alert.alert('Invalid email', 'Enter a valid email address, for example name@example.com.');
       return;
     }
     setLoading(true);

--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -7,6 +7,7 @@ import { BackButton, InputField, PrimaryButton, ScreenContainer } from '@/compon
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { getPasswordRecoveryRedirectUrl } from '@/lib/auth-redirect';
 import { getErrorMessage } from '@/lib/error-message';
+import { isValidEmail } from '@/lib/is-valid-email';
 import { supabase } from '@/lib/supabase';
 
 export default function ForgotPasswordScreen() {
@@ -19,6 +20,10 @@ export default function ForgotPasswordScreen() {
     const trimmed = email.trim();
     if (!trimmed) {
       Alert.alert('Missing email', 'Enter the email you used to sign up.');
+      return;
+    }
+    if (!isValidEmail(trimmed)) {
+      Alert.alert('Invalid email', 'Enter a valid email address, for example name@example.com.');
       return;
     }
 

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -13,6 +13,7 @@ import {
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { navigateAfterAuth } from '@/lib/auth-navigation';
 import { getErrorMessage } from '@/lib/error-message';
+import { isValidEmail } from '@/lib/is-valid-email';
 import { supabase } from '@/lib/supabase';
 import { fetchUserRoles } from '@/lib/user-roles';
 
@@ -26,6 +27,10 @@ export default function LoginScreen() {
     const trimmed = email.trim();
     if (!trimmed || !password) {
       Alert.alert('Missing info', 'Enter email and password.');
+      return;
+    }
+    if (!isValidEmail(trimmed)) {
+      Alert.alert('Invalid email', 'Enter a valid email address, for example name@example.com.');
       return;
     }
     setLoading(true);

--- a/app/restaurant-registration.tsx
+++ b/app/restaurant-registration.tsx
@@ -7,6 +7,7 @@ import { BackButton, InputField, PrimaryButton, ScreenContainer } from '@/compon
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { isDuplicateEmailSignupError, linkRestaurantToExistingAccount } from '@/lib/link-account';
+import { isValidEmail } from '@/lib/is-valid-email';
 import { supabase } from '@/lib/supabase';
 
 export default function RestaurantRegistrationScreen() {
@@ -33,6 +34,10 @@ export default function RestaurantRegistrationScreen() {
         'Missing info',
         'Please fill in restaurant name, business address, email, and password.',
       );
+      return;
+    }
+    if (!isValidEmail(trimmedEmail)) {
+      Alert.alert('Invalid email', 'Enter a valid email address, for example name@example.com.');
       return;
     }
     setLoading(true);

--- a/lib/is-valid-email.ts
+++ b/lib/is-valid-email.ts
@@ -1,0 +1,28 @@
+/**
+ * Client-side check for a plausible public email. Supabase is permissive, so we
+ * validate before sign-up/login to avoid accepting host-only addresses like
+ * "g@g" (no TLD / no dot in the domain).
+ */
+export function isValidEmail(raw: string): boolean {
+  const s = raw.trim();
+  if (!s) return false;
+  if (s.includes(' ') || s.includes('\n')) return false;
+
+  const at = s.indexOf('@');
+  if (at <= 0) return false;
+  if (s.indexOf('@', at + 1) !== -1) return false;
+
+  const local = s.slice(0, at);
+  const domain = s.slice(at + 1);
+  if (!local || !domain) return false;
+  if (local.length > 64 || domain.length > 255) return false;
+  if (!domain.includes('.')) return false;
+
+  const labels = domain.split('.');
+  if (labels.some((l) => l.length === 0)) return false;
+
+  const tld = labels[labels.length - 1] as string;
+  if (tld.length < 2) return false;
+
+  return true;
+}

--- a/tests/is-valid-email.test.ts
+++ b/tests/is-valid-email.test.ts
@@ -1,0 +1,27 @@
+import { isValidEmail } from '@/lib/is-valid-email';
+
+describe('isValidEmail', () => {
+  it('rejects host-only domains (issue #153)', () => {
+    expect(isValidEmail('g@g')).toBe(false);
+    expect(isValidEmail('a@b')).toBe(false);
+  });
+
+  it('accepts common public addresses', () => {
+    expect(isValidEmail('jane@example.com')).toBe(true);
+    expect(isValidEmail('a@b.co')).toBe(true);
+    expect(isValidEmail('user+tag@mail.sub.example.com')).toBe(true);
+  });
+
+  it('rejects empty or obviously malformed', () => {
+    expect(isValidEmail('')).toBe(false);
+    expect(isValidEmail('   ')).toBe(false);
+    expect(isValidEmail('nodomain@')).toBe(false);
+    expect(isValidEmail('@nolocal.com')).toBe(false);
+    expect(isValidEmail('a@@b.com')).toBe(false);
+    expect(isValidEmail('a @b.com')).toBe(false);
+  });
+
+  it('rejects single-char TLD after dot', () => {
+    expect(isValidEmail('x@y.c')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #153

## Summary
- Add `isValidEmail()` in `lib/is-valid-email.ts` to require a dotted domain and a TLD of length ≥ 2, so addresses like `g@g` are not accepted.
- Use validation on login, forgot password, diner and restaurant registration before calling Supabase.
- Add unit tests in `tests/is-valid-email.test.ts`.

Made with [Cursor](https://cursor.com)