### PR TITLE
fix: long usernames / display names (#154)

### DIFF
--- a/app/add-restaurant.tsx
+++ b/app/add-restaurant.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components';
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { clampDisplayName, DISPLAY_NAME_MAX_LENGTH } from '@/lib/display-name';
 import { ensureRestaurantRole, upsertRestaurantForOwner } from '@/lib/restaurant-setup';
 
 const CUISINE_OPTIONS = [
@@ -59,7 +60,7 @@ export default function AddRestaurantScreen() {
       }
 
       const { error } = await upsertRestaurantForOwner({
-        name: name.trim(),
+        name: clampDisplayName(name.trim()),
         cuisineNames: cuisines,
         locationShort: location.trim() || undefined,
       });
@@ -94,7 +95,13 @@ export default function AddRestaurantScreen() {
           Use the same account as your diner profile. You can switch between diner and restaurant anytime.
         </Text>
 
-        <InputField label="Restaurant name" placeholder="Your restaurant name" value={name} onChangeText={setName} />
+        <InputField
+          label="Restaurant name"
+          placeholder="Your restaurant name"
+          value={name}
+          onChangeText={(t) => setName(clampDisplayName(t))}
+          maxLength={DISPLAY_NAME_MAX_LENGTH}
+        />
 
         <Text style={styles.sectionLabel}>Cuisine type</Text>
         <View style={styles.pillRow}>

--- a/app/diner-profile.tsx
+++ b/app/diner-profile.tsx
@@ -98,8 +98,12 @@ export default function DinerProfileScreen() {
           <Text style={styles.avatarText}>{initialsFromUser(email, displayName)}</Text>
         </View>
         <View style={styles.profileText}>
-          <Text style={styles.name}>{name}</Text>
-          <Text style={styles.email}>{email || '—'}</Text>
+          <Text style={styles.name} numberOfLines={2} ellipsizeMode="tail">
+            {name}
+          </Text>
+          <Text style={styles.email} numberOfLines={1} ellipsizeMode="middle">
+            {email || '—'}
+          </Text>
         </View>
       </View>
 
@@ -179,6 +183,7 @@ const styles = StyleSheet.create({
   },
   profileText: {
     flex: 1,
+    minWidth: 0,
   },
   name: {
     ...Typography.bodyMedium,

--- a/app/diner-registration.tsx
+++ b/app/diner-registration.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BackButton, InputField, PrimaryButton, ScreenContainer } from '@/components';
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { clampDisplayName, DISPLAY_NAME_MAX_LENGTH } from '@/lib/display-name';
 import { isDuplicateEmailSignupError, linkDinerToExistingAccount } from '@/lib/link-account';
 import { supabase } from '@/lib/supabase';
 
@@ -32,7 +33,7 @@ export default function DinerRegistrationScreen() {
         options: {
           data: {
             role: 'diner',
-            display_name: name.trim(),
+            display_name: clampDisplayName(name.trim()),
           },
         },
       });
@@ -111,7 +112,13 @@ export default function DinerRegistrationScreen() {
         <Text style={styles.heading}>Join as a Diner</Text>
         <Text style={styles.subtitle}>Create an account to explore menus and discover dishes.</Text>
 
-        <InputField label="Name" placeholder="Your name" value={name} onChangeText={setName} />
+        <InputField
+          label="Name"
+          placeholder="Your name"
+          value={name}
+          onChangeText={(t) => setName(clampDisplayName(t))}
+          maxLength={DISPLAY_NAME_MAX_LENGTH}
+        />
         <InputField
           label="Email"
           placeholder="your@email.com"

--- a/app/restaurant-profile.tsx
+++ b/app/restaurant-profile.tsx
@@ -9,6 +9,7 @@ import { InputField, PrimaryButton, RestaurantTabScreenLayout, SecondaryButton }
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { restaurantRoleTheme } from '@/constants/role-theme';
 import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
+import { clampDisplayName, DISPLAY_NAME_MAX_LENGTH } from '@/lib/display-name';
 import { pickAndUploadRestaurantLogo } from '@/lib/restaurant-logo-upload';
 import {
   fetchRestaurantProfile,
@@ -233,7 +234,9 @@ export default function RestaurantProfileScreen() {
           <View style={[styles.heroCard, { borderColor: t.cardAccentBorder }]}>
             <LogoPreview uri={form.logo_url} accent={t.primary} primaryLight={t.primaryLight} name={form.name} />
             <View style={styles.heroText}>
-              <Text style={styles.venueName}>{form.name.trim() || 'Your restaurant'}</Text>
+              <Text style={styles.venueName} numberOfLines={2} ellipsizeMode="tail">
+                {form.name.trim() || 'Your restaurant'}
+              </Text>
               <Text style={styles.venueMeta}>
                 {cuisineDisplay || form.specialty || '—'}
               </Text>
@@ -322,8 +325,9 @@ export default function RestaurantProfileScreen() {
           <InputField
             label="Restaurant name"
             value={form.name}
-            onChangeText={(v) => setField('name', v)}
+            onChangeText={(v) => setField('name', clampDisplayName(v))}
             placeholder="Your restaurant name"
+            maxLength={DISPLAY_NAME_MAX_LENGTH}
             containerStyle={styles.fieldGap}
           />
           <InputField
@@ -392,7 +396,9 @@ export default function RestaurantProfileScreen() {
           <Text style={[styles.sectionTitle, styles.accountTitle]}>Account</Text>
           <View style={[styles.readOnlyEmail, { borderColor: t.cardAccentBorder }]}>
             <Text style={styles.readOnlyLabel}>Email</Text>
-            <Text style={styles.readOnlyValue}>{email}</Text>
+            <Text style={styles.readOnlyValue} numberOfLines={2} ellipsizeMode="middle">
+              {email}
+            </Text>
           </View>
           <SecondaryButton
             text="Change password"
@@ -418,7 +424,9 @@ function ReadBlock({
     <>
       <View style={styles.readBlock}>
         <Text style={styles.readLabel}>{label}</Text>
-        <Text style={styles.readValue}>{value}</Text>
+        <Text style={styles.readValue} numberOfLines={4} ellipsizeMode="tail">
+          {value}
+        </Text>
       </View>
       {!last ? <View style={styles.readDivider} /> : null}
     </>
@@ -520,6 +528,7 @@ const styles = StyleSheet.create({
   },
   heroText: {
     flex: 1,
+    minWidth: 0,
   },
   venueName: {
     ...Typography.bodyMedium,
@@ -551,6 +560,7 @@ const styles = StyleSheet.create({
   readValue: {
     ...Typography.bodyMedium,
     color: Colors.text,
+    minWidth: 0,
   },
   readDivider: {
     height: StyleSheet.hairlineWidth,

--- a/app/restaurant-registration-2.tsx
+++ b/app/restaurant-registration-2.tsx
@@ -8,6 +8,7 @@ import { BackButton, PreferencePill, PrimaryButton, ScreenContainer } from '@/co
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { BorderRadius, Colors, Spacing, Typography } from '@/constants/theme';
 import { navigateAfterAuth } from '@/lib/auth-navigation';
+import { clampDisplayName } from '@/lib/display-name';
 import { upsertRestaurantForOwner } from '@/lib/restaurant-setup';
 import { supabase } from '@/lib/supabase';
 
@@ -81,10 +82,11 @@ export default function RestaurantRegistration2Screen() {
           : Array.isArray(paramName) && typeof paramName[0] === 'string'
             ? paramName[0].trim()
             : '';
-      const name =
+      const name = clampDisplayName(
         fromParam ||
-        (typeof user.user_metadata?.display_name === 'string' && user.user_metadata.display_name) ||
-        'My Restaurant';
+          (typeof user.user_metadata?.display_name === 'string' && user.user_metadata.display_name) ||
+          'My Restaurant',
+      );
 
       const phoneFromReg = paramString(params.phone).trim();
 

--- a/app/restaurant-registration.tsx
+++ b/app/restaurant-registration.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BackButton, InputField, PrimaryButton, ScreenContainer } from '@/components';
 import { useActiveRole } from '@/contexts/ActiveRoleContext';
 import { Colors, Spacing, Typography } from '@/constants/theme';
+import { clampDisplayName, DISPLAY_NAME_MAX_LENGTH } from '@/lib/display-name';
 import { isDuplicateEmailSignupError, linkRestaurantToExistingAccount } from '@/lib/link-account';
 import { supabase } from '@/lib/supabase';
 
@@ -43,7 +44,7 @@ export default function RestaurantRegistrationScreen() {
         options: {
           data: {
             role: 'restaurant',
-            display_name: restaurantName.trim(),
+            display_name: clampDisplayName(restaurantName.trim()),
           },
         },
       });
@@ -133,7 +134,8 @@ export default function RestaurantRegistrationScreen() {
           label="Restaurant Name"
           placeholder="Your restaurant name"
           value={restaurantName}
-          onChangeText={setRestaurantName}
+          onChangeText={(t) => setRestaurantName(clampDisplayName(t))}
+          maxLength={DISPLAY_NAME_MAX_LENGTH}
         />
         <InputField
           label="Business address"

--- a/app/restaurant-review-menu.tsx
+++ b/app/restaurant-review-menu.tsx
@@ -22,6 +22,7 @@ import { restaurantRoleTheme } from '@/constants/role-theme';
 import { Colors, Typography } from '@/constants/theme';
 import { useRestaurantActiveMenuScan } from '@/contexts/RestaurantActiveMenuScanContext';
 import { useGuardActiveRole } from '@/hooks/use-guard-active-role';
+import { clampDisplayName, DISPLAY_NAME_MAX_LENGTH } from '@/lib/display-name';
 import { fetchRestaurantMenuForScan, type RestaurantMenuDishRow } from '@/lib/restaurant-fetch-menu-for-scan';
 import { publishRestaurantMenu } from '@/lib/restaurant-publish-menu';
 import { updateRestaurantMenuScanName } from '@/lib/restaurant-rename-menu-scan';
@@ -184,12 +185,12 @@ export default function RestaurantReviewMenuScreen() {
     if (!scanId) return;
     setRenameSaving(true);
     try {
-      const res = await updateRestaurantMenuScanName(scanId, renameInput);
+      const res = await updateRestaurantMenuScanName(scanId, clampDisplayName(renameInput));
       if (!res.ok) {
         Alert.alert('Could not rename', res.error);
         return;
       }
-      const next = renameInput.trim() || 'Menu';
+      const next = clampDisplayName(renameInput.trim()) || 'Menu';
       setRestaurantName(next);
       Keyboard.dismiss();
       setRenameModalVisible(false);
@@ -379,14 +380,14 @@ export default function RestaurantReviewMenuScreen() {
             <Text style={styles.modalTitle}>Rename menu</Text>
             <TextInput
               value={renameInput}
-              onChangeText={setRenameInput}
+              onChangeText={(t) => setRenameInput(clampDisplayName(t))}
               placeholder="Menu name"
               placeholderTextColor="#6A7282"
               style={styles.modalInput}
               autoCapitalize="words"
               autoCorrect
               editable={!renameSaving}
-              maxLength={120}
+              maxLength={DISPLAY_NAME_MAX_LENGTH}
               returnKeyType="done"
               onSubmitEditing={() => void onConfirmRenameMenu()}
             />
@@ -466,14 +467,14 @@ const styles = StyleSheet.create({
     marginLeft: 2,
   },
   title: {
+    flex: 1,
+    minWidth: 0,
     fontSize: 20,
     fontWeight: '700',
     lineHeight: 30,
     letterSpacing: -0.45,
     color: Colors.text,
     textAlign: 'center',
-    flexShrink: 1,
-    maxWidth: 200,
   },
   modalRoot: {
     flex: 1,

--- a/components/DinerMenuTitleBar.tsx
+++ b/components/DinerMenuTitleBar.tsx
@@ -47,7 +47,7 @@ export function DinerMenuTitleBar({ title, scanId, restaurantName }: DinerMenuTi
         <MaterialCommunityIcons name="arrow-left" size={18} color={FG} />
       </Pressable>
       <View style={styles.titleSlot} pointerEvents="none">
-        <Text style={styles.title} numberOfLines={1}>
+        <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
           {title}
         </Text>
       </View>
@@ -119,5 +119,6 @@ const styles = StyleSheet.create({
     letterSpacing: -0.43,
     color: FG,
     textAlign: 'center',
+    alignSelf: 'stretch',
   },
 });

--- a/lib/display-name.ts
+++ b/lib/display-name.ts
@@ -1,0 +1,11 @@
+/**
+ * Max length for `display_name` in auth metadata, venue names in forms, and
+ * other profile-style labels. Account identity remains unique by email, not
+ * this field.
+ */
+export const DISPLAY_NAME_MAX_LENGTH = 50;
+
+export function clampDisplayName(s: string): string {
+  if (s.length <= DISPLAY_NAME_MAX_LENGTH) return s;
+  return s.slice(0, DISPLAY_NAME_MAX_LENGTH);
+}


### PR DESCRIPTION
## Summary
Fixes [UI bug with long usernames (#154)](https://github.com/qianxuege/PickMyPlate2/issues/154).

- Introduces `DISPLAY_NAME_MAX_LENGTH` (50) and `clampDisplayName()` in `lib/display-name.ts`. Account identity remains unique by email; the cap only bounds profile-style names.
- Enforces the limit on registration, add-restaurant, restaurant profile name field, and menu rename.
- Prevents layout overflow: diner/restaurant profile rows, read blocks, menu title bar, and restaurant review header use `minWidth: 0`, `numberOfLines`, and `ellipsizeMode` as appropriate.

## Test plan
- [ ] Diner registration: name field stops at 50 characters; profile shows ellipsis for existing long metadata.
- [ ] Restaurant flows: same for venue/menu names.
- [ ] Jest: `npm test` (passes locally).

Made with [Cursor](https://cursor.com)