### PR TITLE
Fix keyboard overlap on restaurant edit dish tags input

### DIFF
--- a/app/restaurant-edit-dish/[dishId].tsx
+++ b/app/restaurant-edit-dish/[dishId].tsx
@@ -2,7 +2,20 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Image, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Keyboard,
+  KeyboardEvent,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { PrimaryButton } from '@/components/PrimaryButton';
@@ -82,10 +95,30 @@ export default function RestaurantEditDishScreen() {
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
   const [summaryError, setSummaryError] = useState<string | null>(null);
+  const [keyboardInset, setKeyboardInset] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
 
   useEffect(() => {
     caloriesEstimatedRef.current = caloriesEstimated;
   }, [caloriesEstimated]);
+
+  useEffect(() => {
+    const onKeyboardShow = (event: KeyboardEvent) => {
+      const next = Math.max(0, event.endCoordinates.height - insets.bottom);
+      setKeyboardInset(next);
+    };
+    const onKeyboardHide = () => setKeyboardInset(0);
+
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const showSub = Keyboard.addListener(showEvent, onKeyboardShow);
+    const hideSub = Keyboard.addListener(hideEvent, onKeyboardHide);
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, [insets.bottom]);
 
   useEffect(() => {
     if (!dishId) return;
@@ -409,19 +442,23 @@ export default function RestaurantEditDishScreen() {
         </View>
       </View>
 
-      {loading ? (
-        <View style={styles.centerBlock}>
-          <ActivityIndicator color={t.primary} />
-          <Text style={{ marginTop: 12, ...Typography.body, color: Colors.textSecondary }}>Loading dish…</Text>
-        </View>
-      ) : (
-        <>
-          <ScrollView
-            style={styles.scroll}
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 120 }]}
-            showsVerticalScrollIndicator={false}
-          >
+      <View style={styles.contentWrap}>
+        {loading ? (
+          <View style={styles.centerBlock}>
+            <ActivityIndicator color={t.primary} />
+            <Text style={{ marginTop: 12, ...Typography.body, color: Colors.textSecondary }}>Loading dish…</Text>
+          </View>
+        ) : (
+          <>
+            <ScrollView
+              ref={scrollRef}
+              style={styles.scroll}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 120 + keyboardInset }]}
+              scrollIndicatorInsets={{ bottom: insets.bottom + keyboardInset }}
+              showsVerticalScrollIndicator={false}
+            >
             <View style={styles.section}>
               <Text style={styles.fieldLabel}>Dish Photo</Text>
               <View style={styles.photoPlaceholder}>
@@ -653,6 +690,11 @@ export default function RestaurantEditDishScreen() {
               <TextInput
                 value={tagsText}
                 onChangeText={setTagsText}
+                onFocus={() => {
+                  setTimeout(() => {
+                    scrollRef.current?.scrollToEnd({ animated: true });
+                  }, Platform.OS === 'ios' ? 120 : 60);
+                }}
                 placeholder="Comma-separated tags"
                 placeholderTextColor="#6A7282"
                 style={styles.input}
@@ -660,21 +702,22 @@ export default function RestaurantEditDishScreen() {
             </View>
 
             {imageError ? <Text style={styles.errorText}>{imageError}</Text> : null}
-          </ScrollView>
+            </ScrollView>
 
-          <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]}>
-            <PrimaryButton
-              text="Save Dish"
-              onPress={() => void onSaveDish()}
-              loading={saving}
-              disabled={saving}
-              accentColor={t.primary}
-              accentShadowRgb={t.shadowRgb}
-              style={styles.saveBtn}
-            />
-          </View>
-        </>
-      )}
+            <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]}>
+              <PrimaryButton
+                text="Save Dish"
+                onPress={() => void onSaveDish()}
+                loading={saving}
+                disabled={saving}
+                accentColor={t.primary}
+                accentShadowRgb={t.shadowRgb}
+                style={styles.saveBtn}
+              />
+            </View>
+          </>
+        )}
+      </View>
     </View>
   );
 }
@@ -719,6 +762,7 @@ const styles = StyleSheet.create({
   },
   headerRight: { width: 32 },
   centerBlock: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  contentWrap: { flex: 1 },
   scroll: { flex: 1 },
   scrollContent: {
     paddingHorizontal: 24,

--- a/app/restaurant-edit-dish/[dishId].tsx
+++ b/app/restaurant-edit-dish/[dishId].tsx
@@ -8,6 +8,9 @@ import {
   Image,
   Keyboard,
   KeyboardEvent,
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
   Platform,
   Pressable,
   ScrollView,
@@ -97,6 +100,10 @@ export default function RestaurantEditDishScreen() {
   const [summaryError, setSummaryError] = useState<string | null>(null);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const scrollRef = useRef<ScrollView>(null);
+  const scrollMetricsRef = useRef({ y: 0, viewportHeight: 0 });
+  const footerHeightRef = useRef(0);
+  const tagsLayoutRef = useRef({ y: 0, height: 0 });
+  const tagsFocusedRef = useRef(false);
 
   useEffect(() => {
     caloriesEstimatedRef.current = caloriesEstimated;
@@ -119,6 +126,49 @@ export default function RestaurantEditDishScreen() {
       hideSub.remove();
     };
   }, [insets.bottom]);
+
+  const ensureTagsVisible = useCallback(() => {
+    const scroll = scrollRef.current;
+    if (!scroll || !tagsFocusedRef.current) return;
+
+    const { y: scrollY, viewportHeight } = scrollMetricsRef.current;
+    const { y: tagsY, height: tagsHeight } = tagsLayoutRef.current;
+    if (viewportHeight <= 0 || tagsHeight <= 0) return;
+
+    const visibilityMargin = 12;
+    const blockedBottom = keyboardInset + footerHeightRef.current + visibilityMargin;
+    const visibleBottom = scrollY + viewportHeight - blockedBottom;
+    const tagsBottom = tagsY + tagsHeight;
+    const delta = tagsBottom - visibleBottom;
+
+    if (delta > 0) {
+      scroll.scrollTo({ y: Math.max(0, scrollY + delta), animated: true });
+    }
+  }, [keyboardInset]);
+
+  useEffect(() => {
+    if (keyboardInset <= 0 || !tagsFocusedRef.current) return;
+    requestAnimationFrame(() => ensureTagsVisible());
+  }, [keyboardInset, ensureTagsVisible]);
+
+  const onScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollMetricsRef.current.y = event.nativeEvent.contentOffset.y;
+  }, []);
+
+  const onScrollLayout = useCallback((event: LayoutChangeEvent) => {
+    scrollMetricsRef.current.viewportHeight = event.nativeEvent.layout.height;
+  }, []);
+
+  const onFooterLayout = useCallback((event: LayoutChangeEvent) => {
+    footerHeightRef.current = event.nativeEvent.layout.height;
+  }, []);
+
+  const onTagsSectionLayout = useCallback((event: LayoutChangeEvent) => {
+    tagsLayoutRef.current = {
+      y: event.nativeEvent.layout.y,
+      height: event.nativeEvent.layout.height,
+    };
+  }, []);
 
   useEffect(() => {
     if (!dishId) return;
@@ -453,6 +503,9 @@ export default function RestaurantEditDishScreen() {
             <ScrollView
               ref={scrollRef}
               style={styles.scroll}
+              onLayout={onScrollLayout}
+              onScroll={onScroll}
+              scrollEventThrottle={16}
               keyboardShouldPersistTaps="handled"
               keyboardDismissMode="on-drag"
               contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 120 + keyboardInset }]}
@@ -685,15 +738,17 @@ export default function RestaurantEditDishScreen() {
               </Pressable>
             </View>
 
-            <View style={styles.section}>
+            <View style={styles.section} onLayout={onTagsSectionLayout}>
               <Text style={styles.fieldLabel}>AI Generated Tags (optional)</Text>
               <TextInput
                 value={tagsText}
                 onChangeText={setTagsText}
                 onFocus={() => {
-                  setTimeout(() => {
-                    scrollRef.current?.scrollToEnd({ animated: true });
-                  }, Platform.OS === 'ios' ? 120 : 60);
+                  tagsFocusedRef.current = true;
+                  ensureTagsVisible();
+                }}
+                onBlur={() => {
+                  tagsFocusedRef.current = false;
                 }}
                 placeholder="Comma-separated tags"
                 placeholderTextColor="#6A7282"
@@ -704,7 +759,7 @@ export default function RestaurantEditDishScreen() {
             {imageError ? <Text style={styles.errorText}>{imageError}</Text> : null}
             </ScrollView>
 
-            <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]}>
+            <View style={[styles.footer, { paddingBottom: Math.max(insets.bottom, 16) }]} onLayout={onFooterLayout}>
               <PrimaryButton
                 text="Save Dish"
                 onPress={() => void onSaveDish()}


### PR DESCRIPTION
## Summary
- add keyboard-height-aware bottom inset on the edit dish scroll view
- auto-scroll when the AI Generated Tags input is focused so the field stays above the keyboard
- preserve footer/save button layout while preventing the tags input border from being clipped

## Test plan
- [x] Open Restaurant Edit Dish screen
- [x] Focus AI Generated Tags input with iOS keyboard open
- [x] Verify bottom border remains visible and field is editable
- [x] Verify save footer remains accessible

Fixes #167

Made with [Cursor](https://cursor.com)