### PR TITLE
Fix #158: reject non-menu uploads in /v1/parse-menu

### DIFF
--- a/app/diner-menu-processing.tsx
+++ b/app/diner-menu-processing.tsx
@@ -165,7 +165,11 @@ export default function DinerMenuProcessingScreen() {
     });
 
     if (!api.ok) {
-      failAndHome('Could not parse menu', api.error);
+      if (api.error === 'not_a_menu') {
+        failAndHome('Not a menu', 'Please upload a menu photo.');
+      } else {
+        failAndHome('Could not parse menu', api.error);
+      }
       return;
     }
 

--- a/app/restaurant-menu-processing.tsx
+++ b/app/restaurant-menu-processing.tsx
@@ -141,7 +141,11 @@ export default function RestaurantMenuProcessingScreen() {
     });
 
     if (!api.ok) {
-      failAndHome('Could not parse menu', api.error);
+      if (api.error === 'not_a_menu') {
+        failAndHome('Not a menu', 'Please upload a menu photo.');
+      } else {
+        failAndHome('Could not parse menu', api.error);
+      }
       return;
     }
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -297,7 +297,7 @@ def create_app() -> Flask:
                 _log_ocr_text(ocr_text)
 
         try:
-            from llm_menu_vertex import parse_menu_with_vertex
+            from llm_menu_vertex import NotAMenuError, parse_menu_with_vertex
             from parsed_menu_validate import (
                 assign_server_uuid_ids,
                 add_personalized_avoidance_tags,
@@ -316,6 +316,17 @@ def create_app() -> Flask:
                 image_bytes=image_bytes,
                 storage_path=path_clean,
                 debug_llm=_is_flask_debug(app),
+            )
+        except NotAMenuError:
+            return (
+                jsonify(
+                    {
+                        "ok": False,
+                        "error": "not_a_menu",
+                        "message": "The uploaded image does not appear to be a menu.",
+                    }
+                ),
+                400,
             )
         except Exception as e:
             return jsonify({"ok": False, "error": f"llm_failed: {e!s}"}), 502

--- a/backend/llm_menu_vertex.py
+++ b/backend/llm_menu_vertex.py
@@ -24,6 +24,10 @@ from typing import Any
 _vertex_initialized = False
 
 
+class NotAMenuError(RuntimeError):
+    """Raised when the LLM determines the uploaded image is not a restaurant menu."""
+
+
 def _ensure_vertex() -> None:
     global _vertex_initialized
     if _vertex_initialized:
@@ -59,6 +63,8 @@ def _json_from_model_text(text: str) -> Any:
 
 
 SYSTEM_INSTRUCTION = """You are PickMyPlate's menu parser. Your job is to turn menu image (and optionally OCR text) into ONE JSON object. The output shape is fixed (schema_version 1) — same keys and types every time for menu content — so downstream code can parse it. Section and item "id" fields are optional (the server assigns UUIDs). Never omit required keys for titles, items, prices, tags, etc.
+
+Judge whether the input is a menu first. Always include a top-level boolean field "is_menu". If the image and OCR text do not depict a restaurant/food menu (e.g. a photo of a single dish, a receipt, a person, a landscape, or any non-menu content), set "is_menu": false, set restaurant_name to null, set sections to [], and do not invent dishes. Otherwise set "is_menu": true and parse the menu normally.
 
 Hard rules:
 1. Output a single JSON object only. No markdown, no commentary outside JSON.
@@ -172,6 +178,12 @@ def _generate_json(
     return parsed
 
 
+def _raise_if_not_menu(parsed: dict[str, Any]) -> None:
+    """If the model marked is_menu=false, surface a typed error so callers skip the retry path."""
+    if parsed.get("is_menu") is False:
+        raise NotAMenuError("The uploaded image does not appear to be a menu.")
+
+
 def parse_menu_with_vertex(
     *,
     ocr_text: str | None,
@@ -181,7 +193,8 @@ def parse_menu_with_vertex(
     debug_llm: bool = False,
 ) -> dict[str, Any]:
     """
-    Returns a ParsedMenu dict (schema v1). Raises RuntimeError on failure.
+    Returns a ParsedMenu dict (schema v1). Raises NotAMenuError when the model
+    determines the image isn't a menu, or RuntimeError on other failures.
     """
     mime = _mime_from_storage_path(storage_path)
     strategy = _strategy()
@@ -193,31 +206,37 @@ def parse_menu_with_vertex(
     # strategy is used below
 
     if strategy == "image_only":
-        return _generate_json(
+        result = _generate_json(
             user_message=msg,
             image_bytes=image_bytes,
             image_mime=mime,
             debug_llm=debug_llm,
             attempt_label="image_only",
         )
+        _raise_if_not_menu(result)
+        return result
 
     if strategy == "multimodal_always":
-        return _generate_json(
+        result = _generate_json(
             user_message=msg,
             image_bytes=image_bytes,
             image_mime=mime,
             debug_llm=debug_llm,
             attempt_label="multimodal_always",
         )
+        _raise_if_not_menu(result)
+        return result
 
     if strategy == "text_only":
-        return _generate_json(
+        result = _generate_json(
             user_message=msg,
             image_bytes=None,
             image_mime=None,
             debug_llm=debug_llm,
             attempt_label="text_only",
         )
+        _raise_if_not_menu(result)
+        return result
 
     # text_first: try text, then image+text
     from parsed_menu_validate import (
@@ -236,6 +255,7 @@ def parse_menu_with_vertex(
         debug_llm=debug_llm,
         attempt_label="text_first",
     )
+    _raise_if_not_menu(first)
     normalize_llm_menu_shape(first)
     normalize_llm_scalar_coercions(first)
     assign_server_uuid_ids(first)
@@ -267,4 +287,5 @@ def parse_menu_with_vertex(
         debug_llm=debug_llm,
         attempt_label="text_first_retry_image",
     )
+    _raise_if_not_menu(second)
     return second


### PR DESCRIPTION
## Summary
- Adds an `is_menu` boolean to the Gemini system prompt; the model now decides up front whether the upload actually shows a restaurant menu and emits `sections: []` for non-menus instead of inventing dishes.
- Backend: new typed `NotAMenuError` short-circuits the `text_first` image retry path, and `/v1/parse-menu` returns `400 {"ok": false, "error": "not_a_menu", "message": "..."}` so the client can react.
- Frontend: both `diner-menu-processing` and `restaurant-menu-processing` show **"Not a menu — Please upload a menu photo."** when the API responds with `not_a_menu`.

Closes #158.

## Test plan
- [x] `cd backend && python -m pytest tests/ -q` — 13 passed
- [x] `npm test` — 313 passed across 21 suites
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: upload a single-dish photo → expect "Not a menu — Please upload a menu photo." alert and a return to the home screen
- [ ] Manual: upload a real menu photo → expect normal parse (regression check across both diner and restaurant flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)