### PR TITLE
fix: partner QR clarity, restaurant menu UX, Supabase session recovery

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,10 @@
 import { Stack } from "expo-router";
+import { LogBox } from "react-native";
 
 import { AuthDeepLinkHandler } from "@/components/AuthDeepLinkHandler";
+
+// GoTrue logs before returning; we clear bad tokens in ActiveRoleContext.
+LogBox.ignoreLogs(["Invalid Refresh Token", "Refresh Token Not Found"]);
 import { ActiveRoleProvider } from "@/contexts/ActiveRoleContext";
 import { DinerActiveMenuScanProvider } from "@/contexts/DinerActiveMenuScanContext";
 import { RestaurantActiveMenuScanProvider } from "@/contexts/RestaurantActiveMenuScanContext";

--- a/app/restaurant-edit-dish/[dishId].tsx
+++ b/app/restaurant-edit-dish/[dishId].tsx
@@ -458,7 +458,7 @@ export default function RestaurantEditDishScreen() {
         Alert.alert('Save failed', result.error);
         return;
       }
-      router.replace({ pathname: '/restaurant-review-menu', params: { scanId } });
+      router.back();
     } catch (e) {
       Alert.alert('Save failed', e instanceof Error ? e.message : 'Unknown error');
     } finally {

--- a/app/restaurant-menu.tsx
+++ b/app/restaurant-menu.tsx
@@ -47,6 +47,8 @@ export default function RestaurantMenuScreen() {
   const [qrVisible, setQrVisible] = useState(false);
   const [partnerLink, setPartnerLink] = useState<string | null>(null);
   const [partnerQrUrl, setPartnerQrUrl] = useState<string | null>(null);
+  const [livePublishedMenuTitle, setLivePublishedMenuTitle] = useState<string | null>(null);
+  const [qrModalPublishedTitle, setQrModalPublishedTitle] = useState<string | null>(null);
 
   useFocusEffect(
     useCallback(() => {
@@ -65,6 +67,16 @@ export default function RestaurantMenuScreen() {
           if (cancelled) return;
           const pubId = restRow?.published_menu_scan_id ? String(restRow.published_menu_scan_id) : null;
           setPublishedScanId(pubId);
+          if (pubId) {
+            const live = await fetchRestaurantMenuForScan(pubId);
+            if (!cancelled && live.ok) {
+              setLivePublishedMenuTitle(live.scan.restaurant_name?.trim() || 'Published menu');
+            } else if (!cancelled) {
+              setLivePublishedMenuTitle('Published menu');
+            }
+          } else if (!cancelled) {
+            setLivePublishedMenuTitle(null);
+          }
 
           const aid = activeScanId?.trim();
           if (aid && !(await scanBelongsToOwnerRestaurant(aid))) {
@@ -140,6 +152,7 @@ export default function RestaurantMenuScreen() {
       }
       setPartnerLink(buildPartnerMenuLink(res.token));
       setPartnerQrUrl(buildPartnerMenuQrUrl(res.token));
+      setQrModalPublishedTitle(res.publishedMenuTitle);
       setQrVisible(true);
     } finally {
       setQrBusy(false);
@@ -193,17 +206,20 @@ export default function RestaurantMenuScreen() {
     );
   }
 
+  const activeId = activeScanId?.trim() ?? '';
+  const viewingDraftWhileLiveExists =
+    Boolean(activeId) && Boolean(publishedScanId) && activeId !== publishedScanId;
   return (
     <RestaurantTabScreenLayout activeTab="menu">
       {/* Header */}
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle} numberOfLines={1}>
-          {activeScanId?.trim() ? menuTitle : 'My Menus'}
+          {activeScanId?.trim() ? 'Menu' : 'My Menus'}
         </Text>
         <View style={styles.actionsRow}>
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Generate partner QR"
+            accessibilityLabel="Generate partner QR for your live published menu"
             onPress={() => void openQrModal()}
             disabled={qrBusy || !publishedScanId}
             style={({ pressed }) => [
@@ -243,35 +259,50 @@ export default function RestaurantMenuScreen() {
       ) : (
         <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <View style={styles.menuDetailHeader}>
-            <Text style={styles.sectionTitle}>{menuTitle}</Text>
-            <Pressable
-              accessibilityRole="button"
-              onPress={() =>
-                router.push({
-                  pathname: '/restaurant-review-menu',
-                  params: { scanId: activeScanId?.trim() ?? '' },
-                })
-              }
-              style={({ pressed }) => [styles.editBtn, pressed && { opacity: 0.8 }]}
-            >
-              <MaterialCommunityIcons name="pencil-outline" size={14} color={t.primaryDark} />
-              <Text style={styles.editBtnText}>Edit</Text>
-            </Pressable>
+            <Text style={styles.sectionTitle} numberOfLines={1}>
+              {menuTitle}
+            </Text>
+            <View style={styles.menuDetailActions}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Edit menu, review dishes, and publish when ready"
+                onPress={() =>
+                  router.push({
+                    pathname: '/restaurant-review-menu',
+                    params: { scanId: activeId },
+                  })
+                }
+                style={({ pressed }) => [styles.editBtn, pressed && { opacity: 0.8 }]}
+              >
+                <MaterialCommunityIcons name="pencil-outline" size={14} color={t.primaryDark} />
+                <Text style={styles.editBtnText}>Edit</Text>
+              </Pressable>
+            </View>
           </View>
 
           {activeScanId?.trim() === publishedScanId ? (
             <View style={styles.liveBar}>
               <MaterialCommunityIcons name="check-circle" size={14} color={t.primaryDark} />
-              <Text style={styles.liveBarText}>This menu is currently live for customers</Text>
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => void openQrModal()}
-                disabled={qrBusy}
-                style={({ pressed }) => [styles.qrInlineBtn, pressed && { opacity: 0.85 }]}
-              >
-                <MaterialCommunityIcons name="qrcode" size={14} color={Colors.white} />
-                <Text style={styles.qrInlineBtnText}>QR Code</Text>
-              </Pressable>
+              <Text style={styles.liveBarText}>
+                This menu is live for customers. Tap the QR icon in the header (top right) to share it.
+              </Text>
+            </View>
+          ) : viewingDraftWhileLiveExists ? (
+            <View style={styles.draftQrInfo}>
+              <MaterialCommunityIcons name="information-outline" size={16} color={Colors.textSecondary} />
+              <Text style={styles.draftQrInfoText}>
+                Partner QR always opens your live menu
+                {livePublishedMenuTitle ? ` ("${livePublishedMenuTitle}")` : ''}. Tap Edit above to review dishes,
+                then use Publish on the next screen when you are ready to replace what diners see.
+              </Text>
+            </View>
+          ) : activeId && !publishedScanId ? (
+            <View style={styles.draftQrInfo}>
+              <MaterialCommunityIcons name="qrcode" size={16} color={Colors.textSecondary} />
+              <Text style={styles.draftQrInfoText}>
+                Tap Edit above to review this menu, then use Publish on the next screen when ready. After that, use
+                the header QR icon so diners can open it.
+              </Text>
             </View>
           ) : null}
 
@@ -324,12 +355,29 @@ export default function RestaurantMenuScreen() {
       )}
 
       {/* QR Modal */}
-      <Modal visible={qrVisible} transparent animationType="fade" onRequestClose={() => setQrVisible(false)}>
+      <Modal
+        visible={qrVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => {
+          setQrModalPublishedTitle(null);
+          setQrVisible(false);
+        }}
+      >
         <View style={styles.modalBackdrop}>
           <View style={styles.modalCard}>
             <Text style={styles.modalTitle}>Partner Menu QR</Text>
             {partnerQrUrl ? <Image source={{ uri: partnerQrUrl }} style={styles.qrPreview} accessibilityLabel="Partner menu QR code" /> : null}
-            <Text style={styles.modalHint}>Scan this to open your published digital menu.</Text>
+            <Text style={styles.modalHint}>
+              Diners scan this to open{' '}
+              {qrModalPublishedTitle ? `"${qrModalPublishedTitle}"` : 'your published menu'} - your current live menu.
+            </Text>
+            {viewingDraftWhileLiveExists ? (
+              <Text style={styles.modalHintSecondary}>
+                You are viewing a different menu on this screen; the QR still opens the live menu until you tap Edit,
+                then Publish for diners on the next screen.
+              </Text>
+            ) : null}
             {partnerLink ? (
               <Text style={styles.linkText} numberOfLines={3}>
                 {partnerLink}
@@ -343,7 +391,13 @@ export default function RestaurantMenuScreen() {
                 <Text style={styles.modalActionText}>Save PNG</Text>
               </Pressable>
             </View>
-            <Pressable style={styles.modalCloseBtn} onPress={() => setQrVisible(false)}>
+            <Pressable
+              style={styles.modalCloseBtn}
+              onPress={() => {
+                setQrModalPublishedTitle(null);
+                setQrVisible(false);
+              }}
+            >
               <Text style={styles.modalCloseText}>Close</Text>
             </Pressable>
           </View>
@@ -415,8 +469,18 @@ const styles = StyleSheet.create({
     color: Colors.white,
   },
 
-  sectionTitle: { ...Typography.headingSmall, fontSize: 15, fontWeight: '700', color: Colors.text, marginTop: 4 },
-  menuDetailHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  sectionTitle: {
+    ...Typography.headingSmall,
+    fontSize: 15,
+    fontWeight: '700',
+    color: Colors.text,
+    marginTop: 4,
+    flex: 1,
+    minWidth: 0,
+    marginRight: 4,
+  },
+  menuDetailHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  menuDetailActions: { flexDirection: 'row', alignItems: 'center', gap: 8, flexShrink: 0 },
   editBtn: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -439,17 +503,23 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: t.cardAccentBorder,
   },
-  liveBarText: { ...Typography.caption, color: t.primaryDark, flex: 1 },
-  qrInlineBtn: {
+  liveBarText: { ...Typography.caption, color: t.primaryDark, flex: 1, lineHeight: 18 },
+  draftQrInfo: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    backgroundColor: t.primaryDark,
-    borderRadius: BorderRadius.full,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
+    alignItems: 'flex-start',
+    gap: 8,
+    backgroundColor: '#F8FAFC',
+    borderRadius: BorderRadius.base,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E4E7EC',
   },
-  qrInlineBtnText: { fontSize: 12, fontWeight: '700', color: Colors.white },
+  draftQrInfoText: {
+    ...Typography.caption,
+    color: Colors.textSecondary,
+    flex: 1,
+    lineHeight: 18,
+  },
 
   // Dish cards
   dishCard: {
@@ -496,6 +566,14 @@ const styles = StyleSheet.create({
   modalTitle: { ...Typography.headingSmall, fontWeight: '800', color: Colors.text },
   qrPreview: { width: 220, height: 220, borderRadius: 12, backgroundColor: '#F3F4F6' },
   modalHint: { ...Typography.caption, color: Colors.textSecondary, textAlign: 'center' as const },
+  modalHintSecondary: {
+    ...Typography.caption,
+    color: Colors.textSecondary,
+    textAlign: 'center' as const,
+    fontSize: 12,
+    lineHeight: 17,
+    opacity: 0.95,
+  },
   linkText: { ...Typography.caption, color: Colors.textSecondary, textAlign: 'center' as const },
   modalActions: { flexDirection: 'row', gap: 10, marginTop: 6 },
   modalActionBtn: {

--- a/app/restaurant-review-menu.tsx
+++ b/app/restaurant-review-menu.tsx
@@ -103,6 +103,8 @@ export default function RestaurantReviewMenuScreen() {
   const [renameModalVisible, setRenameModalVisible] = useState(false);
   const [renameInput, setRenameInput] = useState('');
   const [renameSaving, setRenameSaving] = useState(false);
+  /** True when this scan is already published (live) in the database. */
+  const [scanIsPublished, setScanIsPublished] = useState(false);
 
   const load = useCallback(async () => {
     if (!scanId) return;
@@ -113,10 +115,12 @@ export default function RestaurantReviewMenuScreen() {
       setError(result.error);
       setDishes([]);
       setDefaultSectionId(null);
+      setScanIsPublished(false);
       setLoading(false);
       return;
     }
 
+    setScanIsPublished(result.scan.is_published);
     setRestaurantName(result.scan.restaurant_name?.trim() || 'Menu');
     const flat = [...result.dishes].sort((a, b) => a.sort_order - b.sort_order);
     setDishes(flat);
@@ -237,6 +241,16 @@ export default function RestaurantReviewMenuScreen() {
             </Text>
           </View>
         ) : null}
+
+        {!loading && !error && scanId && !scanIsPublished ? (
+          <View style={styles.publishCue}>
+            <MaterialCommunityIcons name="information-outline" size={16} color={t.primaryDark} />
+            <Text style={styles.publishCueText}>
+              Tap a dish to edit details. When everything looks right, use Publish for diners at the bottom to make
+              this menu live.
+            </Text>
+          </View>
+        ) : null}
       </View>
 
       {loading ? (
@@ -348,14 +362,41 @@ export default function RestaurantReviewMenuScreen() {
             <View style={styles.progressTrack}>
               <View style={[styles.progressFill, { width: `${Math.round(reviewProgress * 100)}%` }]} />
             </View>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Publish Menu"
-              onPress={() => void onPublish()}
-              style={({ pressed }) => [styles.publishBtn, pressed && { opacity: 0.92 }]}
-            >
-              <Text style={styles.publishBtnText}>Publish Menu</Text>
-            </Pressable>
+            {scanIsPublished ? (
+              <>
+                <View style={styles.footerLiveRow}>
+                  <MaterialCommunityIcons name="check-circle" size={22} color={t.primaryDark} />
+                  <Text style={styles.footerLiveText}>
+                    This menu is live for customers. Dish edits you save from here update what diners see.
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Back to menu list"
+                  onPress={() => router.back()}
+                  style={({ pressed }) => [styles.doneBtn, pressed && { opacity: 0.9 }]}
+                >
+                  <Text style={styles.doneBtnText}>Done</Text>
+                </Pressable>
+              </>
+            ) : (
+              <>
+                <Text style={styles.publishHint}>
+                  Ready for customers? Publishing makes this the menu diners see (and replaces any previous live menu).
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Publish menu for diners"
+                  onPress={() => void onPublish()}
+                  style={({ pressed }) => [styles.publishBtn, pressed && { opacity: 0.92 }]}
+                >
+                  <View style={styles.publishBtnInner}>
+                    <MaterialCommunityIcons name="upload" size={20} color={Colors.white} />
+                    <Text style={styles.publishBtnText}>Publish for diners</Text>
+                  </View>
+                </Pressable>
+              </>
+            )}
           </View>
         </>
       )}
@@ -559,6 +600,27 @@ const styles = StyleSheet.create({
     color: t.primaryDark,
     fontWeight: '500',
   },
+  publishCue: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    marginTop: 4,
+    marginBottom: 2,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    backgroundColor: t.primaryLight,
+    borderWidth: 1,
+    borderColor: t.cardAccentBorder,
+  },
+  publishCueText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 19,
+    letterSpacing: -0.076,
+    color: t.primaryDark,
+    fontWeight: '500',
+  },
   scroll: { flex: 1 },
   scrollContent: {
     paddingHorizontal: 24,
@@ -747,8 +809,51 @@ const styles = StyleSheet.create({
     borderRadius: 9999,
     backgroundColor: t.primary,
   },
-  publishBtn: {
+  publishHint: {
+    fontSize: 12,
+    lineHeight: 17,
+    letterSpacing: -0.076,
+    color: '#6A7282',
+    textAlign: 'center',
+    marginTop: 4,
+    paddingHorizontal: 4,
+  },
+  footerLiveRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    backgroundColor: t.primaryLight,
+    borderWidth: 1,
+    borderColor: t.cardAccentBorder,
+  },
+  footerLiveText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 19,
+    letterSpacing: -0.076,
+    color: t.primaryDark,
+    fontWeight: '500',
+  },
+  doneBtn: {
     height: 46,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderColor: t.primary,
+    backgroundColor: Colors.white,
+  },
+  doneBtnText: {
+    fontSize: 15,
+    lineHeight: 22,
+    fontWeight: '700',
+    color: t.primary,
+  },
+  publishBtn: {
+    minHeight: 52,
     borderRadius: 14,
     alignItems: 'center',
     justifyContent: 'center',
@@ -764,11 +869,19 @@ const styles = StyleSheet.create({
       default: {},
     }),
   },
+  publishBtnInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+  },
   publishBtnText: {
-    fontSize: 15,
+    fontSize: 16,
     lineHeight: 22,
     letterSpacing: -0.23,
-    fontWeight: '600',
+    fontWeight: '700',
     color: Colors.white,
   },
 });

--- a/app/restaurant-review-menu.tsx
+++ b/app/restaurant-review-menu.tsx
@@ -1,5 +1,5 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Image } from 'expo-image';
 import {
@@ -129,9 +129,11 @@ export default function RestaurantReviewMenuScreen() {
     setLoading(false);
   }, [scanId]);
 
-  useEffect(() => {
-    void load();
-  }, [load]);
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load]),
+  );
 
   const counts = useMemo(() => buildNeedsReviewCounts(dishes), [dishes]);
 

--- a/contexts/ActiveRoleContext.tsx
+++ b/contexts/ActiveRoleContext.tsx
@@ -3,6 +3,7 @@ import type { Session } from '@supabase/supabase-js';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { ACTIVE_APP_ROLE_STORAGE_KEY, type AppRole, isAppRole } from '@/lib/app-role';
+import { isInvalidStoredSessionError } from '@/lib/supabase-auth-errors';
 import { supabase } from '@/lib/supabase';
 import { fetchUserRoles } from '@/lib/user-roles';
 
@@ -53,8 +54,19 @@ export function ActiveRoleProvider({ children }: { children: React.ReactNode }) 
     let cancelled = false;
 
     (async () => {
-      const { data } = await supabase.auth.getSession();
+      const { data, error } = await supabase.auth.getSession();
       if (cancelled) return;
+
+      if (error && isInvalidStoredSessionError(error)) {
+        await supabase.auth.signOut({ scope: 'local' });
+        if (cancelled) return;
+        setSession(null);
+        setRoles([]);
+        setActiveRoleState(null);
+        setBootstrapped(true);
+        return;
+      }
+
       const next = data.session ?? null;
       setSession(next);
       if (next?.user?.id) {
@@ -95,7 +107,15 @@ export function ActiveRoleProvider({ children }: { children: React.ReactNode }) 
   const refreshRoles = useCallback(async () => {
     // Read session from Supabase, not only React state — after signIn (e.g. link diner + restaurant)
     // the in-memory session can lag one tick behind; stale state would clear roles incorrectly.
-    const { data } = await supabase.auth.getSession();
+    const { data, error } = await supabase.auth.getSession();
+    if (error && isInvalidStoredSessionError(error)) {
+      await supabase.auth.signOut({ scope: 'local' });
+      setSession(null);
+      setRoles([]);
+      setActiveRoleState(null);
+      return [];
+    }
+
     const next = data.session ?? null;
     setSession(next);
     const userId = next?.user?.id;

--- a/lib/partner-menu-access.ts
+++ b/lib/partner-menu-access.ts
@@ -6,7 +6,7 @@ import type { RestaurantMenuDishRow } from '@/lib/restaurant-fetch-menu-for-scan
 import { supabase } from '@/lib/supabase';
 
 type OwnerTokenResult =
-  | { ok: true; token: string; scanId: string; restaurantName: string }
+  | { ok: true; token: string; scanId: string; restaurantName: string; publishedMenuTitle: string }
   | { ok: false; error: string };
 
 function randomToken(length = 28): string {
@@ -51,6 +51,16 @@ export async function getOrCreateOwnerPartnerMenuToken(): Promise<OwnerTokenResu
   const restaurantName =
     typeof rest.name === 'string' && rest.name.trim() ? rest.name.trim() : 'Restaurant';
 
+  const { data: publishedScanRow, error: pubScanErr } = await supabase
+    .from('restaurant_menu_scans')
+    .select('restaurant_name')
+    .eq('id', scanId)
+    .maybeSingle();
+  if (pubScanErr) return { ok: false, error: pubScanErr.message };
+  const publishedMenuTitle =
+    (typeof publishedScanRow?.restaurant_name === 'string' && publishedScanRow.restaurant_name.trim()) ||
+    restaurantName;
+
   const { data: existing, error: exErr } = await supabase
     .from('partner_menu_qr_tokens')
     .select('token')
@@ -62,7 +72,7 @@ export async function getOrCreateOwnerPartnerMenuToken(): Promise<OwnerTokenResu
     .maybeSingle();
   if (exErr) return { ok: false, error: exErr.message };
   if (existing?.token) {
-    return { ok: true, token: String(existing.token), scanId, restaurantName };
+    return { ok: true, token: String(existing.token), scanId, restaurantName, publishedMenuTitle };
   }
 
   // Retry on unlikely token collision.
@@ -79,7 +89,7 @@ export async function getOrCreateOwnerPartnerMenuToken(): Promise<OwnerTokenResu
       .select('token')
       .single();
     if (!insErr && inserted?.token) {
-      return { ok: true, token: String(inserted.token), scanId, restaurantName };
+      return { ok: true, token: String(inserted.token), scanId, restaurantName, publishedMenuTitle };
     }
     if (insErr && !insErr.message.toLowerCase().includes('duplicate')) {
       return { ok: false, error: insErr.message };

--- a/lib/restaurant-fetch-menu-for-scan.ts
+++ b/lib/restaurant-fetch-menu-for-scan.ts
@@ -35,7 +35,12 @@ export type RestaurantMenuDishRow = {
 };
 
 export type FetchRestaurantMenuForScanResult =
-  | { ok: true; scan: { id: string; restaurant_name: string | null }; sections: RestaurantMenuSectionRow[]; dishes: RestaurantMenuDishRow[] }
+  | {
+      ok: true;
+      scan: { id: string; restaurant_name: string | null; is_published: boolean };
+      sections: RestaurantMenuSectionRow[];
+      dishes: RestaurantMenuDishRow[];
+    }
   | { ok: false; error: string };
 
 function coerceSpiceLevel(v: unknown): 0 | 1 | 2 | 3 {
@@ -51,7 +56,7 @@ export async function fetchRestaurantMenuForScan(scanId: string): Promise<FetchR
   try {
     const { data: scanRow, error: scanErr } = await supabase
       .from('restaurant_menu_scans')
-      .select('id, restaurant_name')
+      .select('id, restaurant_name, is_published')
       .eq('id', scanId)
       .maybeSingle();
 
@@ -108,7 +113,11 @@ export async function fetchRestaurantMenuForScan(scanId: string): Promise<FetchR
 
     return {
       ok: true,
-      scan: { id: String(scanRow.id), restaurant_name: scanRow.restaurant_name ? String(scanRow.restaurant_name) : null },
+      scan: {
+        id: String(scanRow.id),
+        restaurant_name: scanRow.restaurant_name ? String(scanRow.restaurant_name) : null,
+        is_published: Boolean((scanRow as { is_published?: boolean | null }).is_published),
+      },
       sections: (sections ?? []) as RestaurantMenuSectionRow[],
       dishes,
     };

--- a/lib/supabase-auth-errors.ts
+++ b/lib/supabase-auth-errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Detects GoTrue errors when the persisted session cannot be refreshed
+ * (missing refresh token, revoked session, new Supabase project, cleared app data).
+ */
+export function isInvalidStoredSessionError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const msg =
+    'message' in error && typeof (error as { message: unknown }).message === 'string'
+      ? (error as { message: string }).message
+      : String(error);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('invalid refresh token') ||
+    (lower.includes('refresh token') && lower.includes('not found')) ||
+    lower.includes('refresh token revoked')
+  );
+}

--- a/tests/ActiveRoleContext.test.tsx
+++ b/tests/ActiveRoleContext.test.tsx
@@ -92,6 +92,24 @@ describe('ActiveRoleProvider — initial state', () => {
     expect(result.current.activeRole).toBeNull();
   });
 
+  it('clears corrupt session when getSession reports invalid refresh token', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid Refresh Token: Refresh Token Not Found' },
+    });
+
+    const { result } = renderWithProvider(() => useActiveRole());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(result.current.session).toBeNull();
+    expect(result.current.roles).toEqual([]);
+    expect(result.current.bootstrapped).toBe(true);
+  });
+
   it('sets single role as activeRole automatically', async () => {
     mockGetSession.mockResolvedValue({
       data: { session: { user: { id: 'uid-1' }, access_token: 'tok' } },
@@ -242,6 +260,37 @@ describe('refreshRoles', () => {
     });
 
     expect(roles).toEqual([]);
+    expect(result.current.roles).toEqual([]);
+  });
+
+  it('signs out locally and clears roles when refresh token is invalid', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: 'uid-1' }, access_token: 'tok' } },
+      error: null,
+    });
+    mockFetchUserRoles.mockResolvedValue(['diner']);
+
+    const { result } = renderWithProvider(() => useActiveRole());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid Refresh Token: Refresh Token Not Found' },
+    });
+
+    let roles: string[] = [];
+    await act(async () => {
+      roles = await result.current.refreshRoles();
+    });
+
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(roles).toEqual([]);
+    expect(result.current.session).toBeNull();
     expect(result.current.roles).toEqual([]);
   });
 

--- a/tests/partner-menu-access.test.ts
+++ b/tests/partner-menu-access.test.ts
@@ -130,12 +130,17 @@ describe('getOrCreateOwnerPartnerMenuToken', () => {
     queueFromResults([
       // restaurants query
       { data: { id: 'rest-1', name: 'Burger Place', published_menu_scan_id: 'scan-1' }, error: null },
+      // restaurant_menu_scans (published menu title)
+      { data: { restaurant_name: 'Lunch Menu' }, error: null },
       // partner_menu_qr_tokens query (existing token)
       { data: { token: 'existing-token-abc' }, error: null },
     ]);
     const result = await getOrCreateOwnerPartnerMenuToken();
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.token).toBe('existing-token-abc');
+    if (result.ok) {
+      expect(result.token).toBe('existing-token-abc');
+      expect(result.publishedMenuTitle).toBe('Lunch Menu');
+    }
   });
 
   it('returns ok:true with newly created token when none exists', async () => {
@@ -143,6 +148,7 @@ describe('getOrCreateOwnerPartnerMenuToken', () => {
     queueFromResults([
       // restaurants query
       { data: { id: 'rest-1', name: 'Burger Place', published_menu_scan_id: 'scan-1' }, error: null },
+      { data: { restaurant_name: 'Lunch Menu' }, error: null },
       // partner_menu_qr_tokens query (no existing token)
       { data: null, error: null },
       // insert new token
@@ -150,7 +156,10 @@ describe('getOrCreateOwnerPartnerMenuToken', () => {
     ]);
     const result = await getOrCreateOwnerPartnerMenuToken();
     expect(result.ok).toBe(true);
-    if (result.ok) expect(typeof result.token).toBe('string');
+    if (result.ok) {
+      expect(typeof result.token).toBe('string');
+      expect(result.publishedMenuTitle).toBe('Lunch Menu');
+    }
   });
 });
 
@@ -234,7 +243,7 @@ describe('resolvePartnerTokenToDinerScan', () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: 'uid-1' } }, error: null });
     mockFetchRestaurantMenu.mockResolvedValue({
       ok: true,
-      scan: { id: 'scan-1', restaurant_name: 'Test Restaurant' },
+      scan: { id: 'scan-1', restaurant_name: 'Test Restaurant', is_published: true },
       sections: [{ id: 'sec-1', title: 'Mains', sort_order: 0 }],
       dishes: [],
     });

--- a/tests/supabase-auth-errors.test.ts
+++ b/tests/supabase-auth-errors.test.ts
@@ -1,0 +1,17 @@
+import { isInvalidStoredSessionError } from '@/lib/supabase-auth-errors';
+
+describe('isInvalidStoredSessionError', () => {
+  it('returns true for invalid refresh token messages', () => {
+    expect(
+      isInvalidStoredSessionError({ message: 'Invalid Refresh Token: Refresh Token Not Found' }),
+    ).toBe(true);
+    expect(isInvalidStoredSessionError({ message: 'invalid refresh token' })).toBe(true);
+    expect(isInvalidStoredSessionError({ message: 'Refresh token revoked' })).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isInvalidStoredSessionError({ message: 'Network request failed' })).toBe(false);
+    expect(isInvalidStoredSessionError(null)).toBe(false);
+    expect(isInvalidStoredSessionError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
fixes #163 

- Partner QR: token includes published menu title; header QR when draft; info strips and modal copy; fetch scan is_published for review screen
- Restaurant menu: single Edit to review; duplicate title removed; Publish for diners + cues on review screen; live footer with Done
- Supabase: clear invalid refresh token on getSession; LogBox filter; tests for auth helper and ActiveRoleContext

Made-with: Cursor