### PR TITLE
Show price ranges under budget tier options on personalization page

### DIFF
--- a/app/diner-personalization/1.tsx
+++ b/app/diner-personalization/1.tsx
@@ -38,11 +38,11 @@ import {
 
 const SPICE_OPTIONS = ['Mild', 'Medium', 'Spicy'];
 
-const BUDGET_TIERS: { tier: BudgetTier; hint: string }[] = [
-  { tier: '$', hint: 'Budget-friendly' },
-  { tier: '$$', hint: 'Moderate' },
-  { tier: '$$$', hint: 'Upscale' },
-  { tier: '$$$$', hint: 'Special occasion' },
+const BUDGET_TIERS: { tier: BudgetTier; hint: string; range: string }[] = [
+  { tier: '$', hint: 'Budget-friendly', range: '$0–20' },
+  { tier: '$$', hint: 'Moderate', range: '$20–40' },
+  { tier: '$$$', hint: 'Upscale', range: '$40–60' },
+  { tier: '$$$$', hint: 'Special occasion', range: '$60+' },
 ];
 
 type CuisineItem = { name: string; emoji: string };
@@ -272,7 +272,7 @@ export default function DinerPersonalizationScreen() {
           <Text style={styles.sectionTitle}>Typical budget when dining out? 💵</Text>
           <Text style={styles.sectionSubtitle}>Per person, including tax & tip</Text>
           <View style={styles.budgetGrid}>
-            {BUDGET_TIERS.map(({ tier, hint }) => (
+            {BUDGET_TIERS.map(({ tier, hint, range }) => (
               <View key={tier} style={styles.budgetCell}>
                 <PreferencePill
                   label={tier}
@@ -281,6 +281,7 @@ export default function DinerPersonalizationScreen() {
                   style={styles.budgetPill}
                 />
                 <Text style={styles.budgetHint}>{hint}</Text>
+                <Text style={styles.budgetRange}>{range}</Text>
               </View>
             ))}
           </View>
@@ -584,6 +585,11 @@ const styles = StyleSheet.create({
     ...Typography.small,
     color: Colors.textSecondary,
     marginTop: Spacing.xs,
+    textAlign: 'center',
+  },
+  budgetRange: {
+    ...Typography.small,
+    color: Colors.textPlaceholder,
     textAlign: 'center',
   },
   bottomSpacer: {


### PR DESCRIPTION
## Summary
- Adds a small dollar-range line beneath each budget tier on the new-user preference selection page (\`app/diner-personalization/1.tsx\`):
  - \`\$\` → \`\$0–20\`
  - \`\$\$\` → \`\$20–40\`
  - \`\$\$\$\` → \`\$40–60\`
  - \`\$\$\$\$\` → \`\$60+\`
- The existing descriptive hint (\"Budget-friendly\", \"Moderate\", etc.) is preserved; the price range sits below it in a lighter \`textPlaceholder\` color so the cell reads as: pill → hint → range.
- Change is local to the personalization page only — the underlying \`BudgetTier\` union, persisted preference values, and any other screen that displays the tier (e.g. diner-profile, dish-detail \"Why this dish\" reasons) are untouched.

## Test plan
- [x] \`npm test\` — 350 passed across 25 suites
- [ ] Manual: open the personalization page on a fresh account and confirm the new price-range line is visible under each budget pill, doesn't wrap awkwardly, and selecting a pill still works

## Notes
- TypeScript error already present on main (\`diner-registration.tsx:46\`) is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)